### PR TITLE
Fix concurrent dictionary corruption in TokenTracker

### DIFF
--- a/src/OpenMono.Cli/Session/TokenTracker.cs
+++ b/src/OpenMono.Cli/Session/TokenTracker.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+
 namespace OpenMono.Session;
 
 public sealed class TokenTracker
@@ -8,7 +10,7 @@ public sealed class TokenTracker
     public int ApiCalls { get; private set; }
     public int MaxPromptTokens { get; private set; }
     public int AvgPromptTokens => ApiCalls > 0 ? TotalPromptTokens / ApiCalls : 0;
-    public Dictionary<string, int> ToolUsageCounts { get; } = new(StringComparer.OrdinalIgnoreCase);
+    public ConcurrentDictionary<string, int> ToolUsageCounts { get; } = new(StringComparer.OrdinalIgnoreCase);
     public int FilesModified { get; set; }
     public int FilesCreated { get; set; }
 
@@ -28,8 +30,7 @@ public sealed class TokenTracker
 
     public void RecordToolUse(string toolName)
     {
-        ToolUsageCounts.TryGetValue(toolName, out var count);
-        ToolUsageCounts[toolName] = count + 1;
+        ToolUsageCounts.AddOrUpdate(toolName, 1, (_, count) => count + 1);
     }
 
     public string GetSummary(DateTime sessionStart)


### PR DESCRIPTION
RecordToolUse was using a plain Dictionary<string,int> that gets called from multiple thread-pool threads when read-only tools execute in parallel via Task.Run in ConversationLoop. Replace with ConcurrentDictionary and atomic AddOrUpdate to eliminate the race condition.

Logged error:
```
[2026-05-07 17:25:34.849] [ERROR] System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
   at System.Collections.Generic.Dictionary`2.FindValue(TKey key)
   at OpenMono.Session.ConversationLoop.ExecuteSingleToolAsync(ToolCall call, ITool tool, ToolContext context, CancellationToken ct) in C:\Users\Andrej\OpenMonoAgent.ai\src\OpenMono.Cli\Session\ConversationLoop.cs:line 710
   at OpenMono.Session.ConversationLoop.ExecuteToolCallsWithInflightAsync(List`1 toolCalls, Dictionary`2 inFlightTasks, ToolContext context, CancellationTokenSource siblingAbortCts, CancellationToken ct) in C:\Users\Andrej\OpenMonoAgent.ai\src\OpenMono.Cli\Session\ConversationLoop.cs:line 615
   at OpenMono.Session.ConversationLoop.RunTurnAsync(String userInput, CancellationToken ct) in C:\Users\Andrej\OpenMonoAgent.ai\src\OpenMono.Cli\Session\ConversationLoop.cs:line 279
   at Program.<<Main>$>g__RunAgentAsync|0_0(String endpoint, String model, String workdir, String configPath, Boolean verbose, Boolean showDetail, Nullable`1 useTui) in C:\Users\Andrej\OpenMonoAgent.ai\src\OpenMono.Cli\Program.cs:line 346
```