### PR TITLE
Add cross-distro Linux support (Fedora, RHEL, Arch, openSUSE)

### DIFF
--- a/get-openmono.sh
+++ b/get-openmono.sh
@@ -17,7 +17,18 @@ NC='\033[0m'
 info() { echo -e "${BLUE}[INFO]${NC} $*"; }
 ok()   { echo -e "${GREEN}[OK]${NC} $*"; }
 err()  { echo -e "${RED}[ERROR]${NC} $*" >&2; }
-die()  { err "$*"; exit 1; }
+die() { err "$*"; exit 1; }
+
+pkg_install_hint() {
+  if command -v dnf &>/dev/null; then echo "sudo dnf install"
+  elif command -v yum &>/dev/null; then echo "sudo yum install"
+  elif command -v apt &>/dev/null; then echo "sudo apt install"
+  elif command -v pacman &>/dev/null; then echo "sudo pacman -S"
+  elif command -v zypper &>/dev/null; then echo "sudo zypper install"
+  elif command -v brew &>/dev/null; then echo "brew install"
+  else echo "your package manager's install command for"
+  fi
+}
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
@@ -38,8 +49,8 @@ done
 
 # ── Preflight checks ──────────────────────────────────────────────────────────
 
-command -v git  &>/dev/null || die "git is required – install it first: sudo apt install git"
-command -v curl &>/dev/null || die "curl is required – install it first: sudo apt install curl"
+command -v git &>/dev/null || die "git is required – install it first: $(pkg_install_hint) git"
+command -v curl &>/dev/null || die "curl is required – install it first: $(pkg_install_hint) curl"
 
 # ── Clone or update ───────────────────────────────────────────────────────────
 

--- a/openmono
+++ b/openmono
@@ -534,8 +534,16 @@ cmd_config() {
     mkdir -p "$(dirname "$settings")"
     [[ -f "$settings" ]] || echo '{}' > "$settings"
 
-    if ! command -v jq &>/dev/null; then
-        err "jq is required for 'openmono config'. Install it: sudo apt install jq"
+if ! command -v jq &>/dev/null; then
+    _pkg_hint="install jq via your package manager"
+    if command -v dnf &>/dev/null; then _pkg_hint="sudo dnf install jq"
+    elif command -v yum &>/dev/null; then _pkg_hint="sudo yum install jq"
+    elif command -v apt &>/dev/null; then _pkg_hint="sudo apt install jq"
+    elif command -v pacman &>/dev/null; then _pkg_hint="sudo pacman -S jq"
+    elif command -v zypper &>/dev/null; then _pkg_hint="sudo zypper install jq"
+    elif command -v brew &>/dev/null; then _pkg_hint="brew install jq"
+    fi
+    err "jq is required for 'openmono config'. Install it: $_pkg_hint"
         return 1
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -96,6 +96,17 @@ next_step() {
 # ── Prerequisite Check ────────────────────────────────────────────────────────
 # Verify that install_prereqs.sh has been run successfully before proceeding.
 
+# Cross-distro package check helper (needed for nvidia-container-toolkit check)
+pkg_is_installed() {
+  local pkg="$1"
+  if command -v dpkg &>/dev/null; then dpkg -s "$pkg" &>/dev/null 2>&1
+  elif command -v rpm &>/dev/null; then rpm -q "$pkg" &>/dev/null 2>&1
+  elif command -v pacman &>/dev/null; then pacman -Qi "$pkg" &>/dev/null 2>&1
+  elif command -v zypper &>/dev/null; then zypper search -i "$pkg" &>/dev/null 2>&1 | grep -q "^i.*$pkg"
+  else false
+  fi
+}
+
 check_prerequisites() {
     local missing=()
     local warnings=()
@@ -139,8 +150,8 @@ check_prerequisites() {
         if ! command -v nvidia-smi &>/dev/null; then
             warnings+=("NVIDIA GPU detected but drivers not installed")
         fi
-        if ! dpkg -s nvidia-container-toolkit &>/dev/null 2>&1; then
-            warnings+=("nvidia-container-toolkit not installed (required for GPU Docker)")
+  if ! command -v nvidia-container-toolkit &>/dev/null 2>&1 && ! pkg_is_installed nvidia-container-toolkit; then
+    warnings+=("nvidia-container-toolkit not installed (required for GPU Docker)")
         fi
     fi
 

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -2,15 +2,15 @@
 set -euo pipefail
 
 # ──────────────────────────────────────────────────────────────────────────────
-# OpenMono.ai — Prerequisite Installer for Ubuntu
+# OpenMono.ai — Prerequisite Installer for Linux
 #
-# Installs: Docker, git, cmake, curl, jq, .NET 10, ripgrep, build-essential,
-#           (and CUDA + nvidia-container-toolkit if an NVIDIA GPU is detected).
+# Installs: Docker, git, cmake, curl, jq, .NET 10, ripgrep, build tools,
+# (and CUDA + nvidia-container-toolkit if an NVIDIA GPU is detected).
 #
 # Options:
-#   OPENMONO_VERBOSE=1    Show detailed command output
+# OPENMONO_VERBOSE=1 Show detailed command output
 #
-# Tested on: Ubuntu 24.04 LTS
+# Tested on: Ubuntu 24.04, Fedora 43, RHEL/CentOS 9, Arch, openSUSE Tumbleweed
 # ──────────────────────────────────────────────────────────────────────────────
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -19,30 +19,30 @@ source "$SCRIPT_DIR/lib/log.sh"
 
 # Ensure REPO_DIR is set (exported from openmono script)
 if [[ -z "${REPO_DIR:-}" ]]; then
-    REPO_DIR="$(dirname "$SCRIPT_DIR")"
+  REPO_DIR="$(dirname "$SCRIPT_DIR")"
 fi
 
 # Add openmono to PATH for current session
 export PATH="$REPO_DIR:$PATH"
 
-# Add to shell rc files for future sessions (Ubuntu/Linux)
+# Add to shell rc files for future sessions (Linux)
 for rc_file in "$HOME/.bashrc" "$HOME/.zshrc"; do
-    if [ -f "$rc_file" ] && ! grep -q "export PATH=.*$REPO_DIR" "$rc_file"; then
-        {
-            echo ""
-            echo "# OpenMono.ai CLI"
-            echo "export PATH=$REPO_DIR:\$PATH"
-        } >> "$rc_file"
-    fi
+  if [ -f "$rc_file" ] && ! grep -q "export PATH=.*$REPO_DIR" "$rc_file"; then
+    {
+      echo ""
+      echo "# OpenMono.ai CLI"
+      echo "export PATH=$REPO_DIR:\$PATH"
+    } >> "$rc_file"
+  fi
 done
 
-# Configurable NVIDIA driver version (default: 580-server-open)
+# Configurable NVIDIA driver version (Ubuntu only — other distros auto-select)
 DRIVER_VERSION="${DRIVER_VERSION:-580-server-open}"
 
 # GPU mode: determined by flags or user prompt (exported for install.sh)
 GPU_MODE="${OPENMONO_GPU:-}"
 if [[ -n "${OPENMONO_CPU:-}" ]]; then
-    GPU_MODE=0
+  GPU_MODE=0
 fi
 export GPU_MODE
 
@@ -55,16 +55,42 @@ banner "OpenMono.ai Prerequisites"
 step 1 $TOTAL_STEPS "Detecting operating system"
 
 if [ ! -f /etc/os-release ]; then
-    die "Cannot detect OS. This script is designed for Ubuntu."
+  die "Cannot detect OS (/etc/os-release missing). This script is designed for Linux."
 fi
 
 . /etc/os-release
 
-if [ "$ID" != "ubuntu" ]; then
-    warn "Detected $PRETTY_NAME — this script targets Ubuntu."
-    warn "Continuing, but some steps may need manual adjustment."
+SUPPORTED_IDS="ubuntu debian fedora rhel centos rocky almalinux arch manjaro opensuse-tumbleweed opensuse-leap suse"
+_is_supported=false
+for _id in $SUPPORTED_IDS; do
+  if [ "$ID" = "$_id" ] || [ "${ID_LIKE:-}" = "$_id" ]; then
+    _is_supported=true
+    break
+  fi
+done
+
+if [ "$_is_supported" = false ]; then
+  warn "Detected $PRETTY_NAME — this is not a officially tested distribution."
+  warn "Continuing, but some steps may need manual adjustment."
 else
-    ok "$PRETTY_NAME"
+  ok "$PRETTY_NAME"
+fi
+
+# ── Detect package manager ────────────────────────────────────────────────────
+# Sets PKG_MGR to one of: apt, dnf, yum, pacman, zypper, unknown
+
+if command -v dnf &>/dev/null; then
+  PKG_MGR="dnf"
+elif command -v yum &>/dev/null; then
+  PKG_MGR="yum"
+elif command -v apt-get &>/dev/null; then
+  PKG_MGR="apt"
+elif command -v pacman &>/dev/null; then
+  PKG_MGR="pacman"
+elif command -v zypper &>/dev/null; then
+  PKG_MGR="zypper"
+else
+  PKG_MGR="unknown"
 fi
 
 # ── Step 2: Ensure sudo ───────────────────────────────────────────────────────
@@ -72,81 +98,266 @@ fi
 step 2 $TOTAL_STEPS "Checking privileges"
 
 if [ "$(id -u)" -eq 0 ]; then
-    SUDO=""
-    ok "Running as root"
+  SUDO=""
+  ok "Running as root"
 else
-    if ! command -v sudo &>/dev/null; then
-        die "sudo is required. Run as root or install sudo first."
-    fi
-    SUDO="sudo"
-    ok "sudo available"
+  if ! command -v sudo &>/dev/null; then
+    die "sudo is required. Run as root or install sudo first."
+  fi
+  SUDO="sudo"
+  ok "sudo available"
 fi
+
+# ── Package management helpers ────────────────────────────────────────────────
+
+pkg_update() {
+  case "$PKG_MGR" in
+    apt)
+      info "Running apt-get update..."
+      run $SUDO apt-get update -qq || die "Failed to update apt package index"
+      ;;
+    dnf)
+      info "Running dnf makecache..."
+      run $SUDO dnf makecache -y 2>/dev/null || true
+      ;;
+    yum)
+      info "Running yum makecache..."
+      run $SUDO yum makecache -y 2>/dev/null || true
+      ;;
+    pacman)
+      info "Running pacman -Sy..."
+      run $SUDO pacman -Sy --noconfirm 2>/dev/null || true
+      ;;
+    zypper)
+      info "Running zypper refresh..."
+      run $SUDO zypper refresh 2>/dev/null || true
+      ;;
+    *)
+      warn "Unknown package manager — skipping package index update"
+      ;;
+  esac
+}
+
+install_pkg() {
+  local pkg="$1"
+  local check_cmd="${2:-$pkg}"
+  if command -v "$check_cmd" &>/dev/null; then
+    ok "$pkg already installed"
+    detail "$(command -v "$check_cmd")"
+    return 0
+  fi
+  info "Installing $pkg..."
+  case "$PKG_MGR" in
+    apt)
+      run $SUDO apt-get install -y -qq "$pkg" || die "Failed to install $pkg"
+      ;;
+    dnf)
+      run $SUDO dnf install -y "$pkg" || die "Failed to install $pkg"
+      ;;
+    yum)
+      run $SUDO yum install -y "$pkg" || die "Failed to install $pkg"
+      ;;
+    pacman)
+      run $SUDO pacman -S --noconfirm "$pkg" || die "Failed to install $pkg"
+      ;;
+    zypper)
+      run $SUDO zypper install -y "$pkg" || die "Failed to install $pkg"
+      ;;
+    *)
+      die "Unknown package manager — cannot install $pkg automatically"
+      ;;
+  esac
+  ok "$pkg installed"
+}
+
+pkg_is_installed() {
+  local pkg="$1"
+  case "$PKG_MGR" in
+    apt)  dpkg -s "$pkg" &>/dev/null 2>&1 ;;
+    dnf)  dnf list installed "$pkg" &>/dev/null 2>&1 ;;
+    yum)  yum list installed "$pkg" &>/dev/null 2>&1 ;;
+    pacman) pacman -Qi "$pkg" &>/dev/null 2>&1 ;;
+    zypper) zypper search -i "$pkg" &>/dev/null 2>&1 | grep -q "^i.*$pkg" ;;
+    *)    false ;;
+  esac
+}
 
 # ── Step 3: Update package index ──────────────────────────────────────────────
 
-step 3 $TOTAL_STEPS "Updating apt package index"
+step 3 $TOTAL_STEPS "Updating package index"
 
-info "Running apt-get update..."
-if ! run $SUDO apt-get update -qq; then
-    die "Failed to update apt package index"
-fi
+pkg_update
 ok "Package index updated"
 
-# ── Step 4: Core tools (git, curl, cmake, build-essential, python3-pip) ──────
+# ── Step 4: Core tools ────────────────────────────────────────────────────────
 
 step 4 $TOTAL_STEPS "Installing core build tools"
-
-install_pkg() {
-    local pkg="$1"
-    local check_cmd="${2:-$pkg}"
-    if command -v "$check_cmd" &>/dev/null; then
-        ok "$pkg already installed"
-        detail "$(command -v "$check_cmd")"
-    else
-        info "Installing $pkg..."
-        if ! run $SUDO apt-get install -y -qq "$pkg"; then
-            die "Failed to install $pkg"
-        fi
-        ok "$pkg installed"
-    fi
-}
 
 install_pkg git git
 install_pkg curl curl
 install_pkg jq jq
 install_pkg cmake cmake
-install_pkg pciutils lspci
 
-if dpkg -s build-essential &>/dev/null 2>&1; then
-    ok "build-essential already installed"
+# pciutils (lspci) — package name varies
+if command -v lspci &>/dev/null; then
+  ok "pciutils already installed"
 else
-    info "Installing build-essential..."
-    run $SUDO apt-get install -y -qq build-essential || die "Failed to install build-essential"
-    ok "build-essential installed"
+  case "$PKG_MGR" in
+    apt)    install_pkg pciutils lspci ;;
+    dnf|yum) install_pkg pciutils lspci ;;
+    pacman) install_pkg pciutils lspci ;;
+    zypper) install_pkg pciutils lspci ;;
+    *)      warn "Cannot auto-install pciutils — lspci will be unavailable" ;;
+  esac
 fi
 
+# Build essentials — package group name varies by distro
+case "$PKG_MGR" in
+  apt)
+    if pkg_is_installed build-essential; then
+      ok "build-essential already installed"
+    else
+      info "Installing build-essential..."
+      run $SUDO apt-get install -y -qq build-essential || die "Failed to install build-essential"
+      ok "build-essential installed"
+    fi
+    ;;
+  dnf|yum)
+    if rpm -q @development-tools &>/dev/null 2>&1 || rpm -q gcc &>/dev/null 2>&1; then
+      ok "development tools already installed"
+    else
+      info "Installing C development tools and libraries..."
+      run $SUDO "$PKG_MGR" group install -y "C Development Tools and Libraries" 2>/dev/null \
+        || run $SUDO "$PKG_MGR" groupinstall -y "Development Tools" 2>/dev/null \
+        || run $SUDO "$PKG_MGR" install -y gcc gcc-c++ make autoconf automake libtool \
+        || die "Failed to install development tools"
+      ok "development tools installed"
+    fi
+    ;;
+  pacman)
+    if pacman -Qi base-devel &>/dev/null 2>&1; then
+      ok "base-devel already installed"
+    else
+      info "Installing base-devel..."
+      run $SUDO pacman -S --noconfirm base-devel || die "Failed to install base-devel"
+      ok "base-devel installed"
+    fi
+    ;;
+  zypper)
+    if zypper search -i -t pattern devel_basis &>/dev/null 2>&1 | grep -q "devel_basis"; then
+      ok "devel_basis pattern already installed"
+    else
+      info "Installing devel_basis pattern..."
+      run $SUDO zypper install -y -t pattern devel_basis || die "Failed to install devel_basis"
+      ok "devel_basis installed"
+    fi
+    ;;
+  *)
+    warn "Unknown package manager — install C compiler and build tools manually"
+    ;;
+esac
+
+# Python pip
 if command -v pip3 &>/dev/null; then
-    ok "python3-pip already installed"
+  ok "python3-pip already installed"
 else
-    info "Installing python3-pip..."
-    run $SUDO apt-get install -y -qq python3-pip || die "Failed to install python3-pip"
-    ok "python3-pip installed"
+  case "$PKG_MGR" in
+    apt)
+      info "Installing python3-pip..."
+      run $SUDO apt-get install -y -qq python3-pip || die "Failed to install python3-pip"
+      ;;
+    dnf)
+      info "Installing python3-pip..."
+      run $SUDO dnf install -y python3-pip || die "Failed to install python3-pip"
+      ;;
+    yum)
+      info "Installing python3-pip..."
+      run $SUDO yum install -y python3-pip || die "Failed to install python3-pip"
+      ;;
+    pacman)
+      info "Installing python-pip..."
+      run $SUDO pacman -S --noconfirm python-pip || die "Failed to install python-pip"
+      ;;
+    zypper)
+      info "Installing python3-pip..."
+      run $SUDO zypper install -y python3-pip || die "Failed to install python3-pip"
+      ;;
+    *)
+      warn "Cannot auto-install pip — install python3-pip manually"
+      ;;
+  esac
+  ok "python3-pip installed"
 fi
 
-if dpkg -s libopenblas-dev &>/dev/null 2>&1; then
-    ok "libopenblas-dev already installed"
-else
-    info "Installing libopenblas-dev..."
-    run $SUDO apt-get install -y -qq libopenblas-dev pkg-config || die "Failed to install libopenblas-dev"
-    ok "libopenblas-dev installed"
-fi
+# OpenBLAS — package name varies
+case "$PKG_MGR" in
+  apt)
+    if pkg_is_installed libopenblas-dev; then
+      ok "libopenblas-dev already installed"
+    else
+      info "Installing libopenblas-dev..."
+      run $SUDO apt-get install -y -qq libopenblas-dev pkg-config || die "Failed to install libopenblas-dev"
+      ok "libopenblas-dev installed"
+    fi
+    ;;
+  dnf|yum)
+    if pkg_is_installed openblas-devel; then
+      ok "openblas-devel already installed"
+    else
+      info "Installing openblas-devel..."
+      run $SUDO "$PKG_MGR" install -y openblas-devel pkgconfig || die "Failed to install openblas-devel"
+      ok "openblas-devel installed"
+    fi
+    ;;
+  pacman)
+    if pacman -Qi openblas &>/dev/null 2>&1; then
+      ok "openblas already installed"
+    else
+      info "Installing openblas..."
+      run $SUDO pacman -S --noconfirm openblas pkgconf || die "Failed to install openblas"
+      ok "openblas installed"
+    fi
+    ;;
+  zypper)
+    if pkg_is_installed libopenblas-devel; then
+      ok "libopenblas-devel already installed"
+    else
+      info "Installing libopenblas-devel..."
+      run $SUDO zypper install -y libopenblas-devel pkg-config || die "Failed to install libopenblas-devel"
+      ok "libopenblas-devel installed"
+    fi
+    ;;
+  *)
+    warn "Cannot auto-install OpenBLAS — install it manually"
+    ;;
+esac
 
+# ripgrep
 if command -v rg &>/dev/null; then
-    ok "ripgrep already installed"
+  ok "ripgrep already installed"
 else
-    info "Installing ripgrep..."
-    run $SUDO apt-get install -y -qq ripgrep || die "Failed to install ripgrep"
-    ok "ripgrep installed"
+  case "$PKG_MGR" in
+    apt)
+      info "Installing ripgrep..."
+      run $SUDO apt-get install -y -qq ripgrep || die "Failed to install ripgrep"
+      ;;
+    dnf|yum)
+      info "Installing ripgrep..."
+      run $SUDO "$PKG_MGR" install -y ripgrep || die "Failed to install ripgrep"
+      ;;
+    pacman)
+      info "Installing ripgrep..."
+      run $SUDO pacman -S --noconfirm ripgrep || die "Failed to install ripgrep"
+      ;;
+    zypper)
+      info "Installing ripgrep..."
+      run $SUDO zypper install -y ripgrep || die "Failed to install ripgrep"
+      ;;
+    *)
+      warn "Cannot auto-install ripgrep — install it manually"
+      ;;
+  esac
+  ok "ripgrep installed"
 fi
 
 # ── Step 5: NVIDIA stack (optional) ──────────────────────────────────────────
@@ -154,113 +365,191 @@ fi
 step 5 $TOTAL_STEPS "Checking for NVIDIA GPU"
 
 HAS_NVIDIA_HW=false
-# Try lspci first (most descriptive)
 if command -v lspci &>/dev/null && lspci 2>/dev/null | grep -qi 'nvidia'; then
-    HAS_NVIDIA_HW=true
-    detail "$(lspci | grep -i nvidia | head -3)"
-# Fallback to /sys (most reliable, no extra tools needed)
+  HAS_NVIDIA_HW=true
+  detail "$(lspci | grep -i nvidia | head -3)"
 elif grep -qi "0x10de" /sys/bus/pci/devices/*/vendor 2>/dev/null; then
-    HAS_NVIDIA_HW=true
-    detail "NVIDIA GPU detected via PCI vendor ID (0x10de)"
+  HAS_NVIDIA_HW=true
+  detail "NVIDIA GPU detected via PCI vendor ID (0x10de)"
 fi
 
-# Determine GPU mode: explicit flag takes precedence, then auto-detect with prompt
 if [[ -z "$GPU_MODE" ]]; then
-    # No flag provided — auto-detect and prompt if NVIDIA hardware is found
-    if [ "$HAS_NVIDIA_HW" = true ] || command -v nvidia-smi &>/dev/null; then
-        echo ""
-        printf "${BLUE}%s${NC}\n" "$(printf '─%.0s' $(seq 1 60))"
-        printf "${BLUE}${BOLD}  NVIDIA GPU Detected${NC}\n"
-        printf "${BLUE}%s${NC}\n" "$(printf '─%.0s' $(seq 1 60))"
-        echo ""
-        printf "  Would you like to install on GPU? ${BOLD}(Y/n)${NC}: "
-        read -r _gpu_choice
-        _gpu_choice="${_gpu_choice:-Y}"
-        if [[ "$_gpu_choice" =~ ^[Yy]$ ]]; then
-            GPU_MODE=1
-        else
-            GPU_MODE=0
-        fi
-        echo ""
+  if [ "$HAS_NVIDIA_HW" = true ] || command -v nvidia-smi &>/dev/null; then
+    echo ""
+    printf "${BLUE}%s${NC}\n" "$(printf '─%.0s' $(seq 1 60))"
+    printf "${BLUE}${BOLD} NVIDIA GPU Detected${NC}\n"
+    printf "${BLUE}%s${NC}\n" "$(printf '─%.0s' $(seq 1 60))"
+    echo ""
+    printf " Would you like to install on GPU? ${BOLD}(Y/n)${NC}: "
+    read -r _gpu_choice
+    _gpu_choice="${_gpu_choice:-Y}"
+    if [[ "$_gpu_choice" =~ ^[Yy]$ ]]; then
+      GPU_MODE=1
     else
-        # No NVIDIA hardware detected
-        GPU_MODE=0
+      GPU_MODE=0
     fi
+    echo ""
+  else
+    GPU_MODE=0
+  fi
 fi
 
 if [ "$GPU_MODE" = 0 ]; then
-    info "GPU mode disabled — skipping CUDA/nvidia-container-toolkit"
+  info "GPU mode disabled — skipping CUDA/nvidia-container-toolkit"
 else
-    ok "GPU mode enabled — installing NVIDIA stack"
+  ok "GPU mode enabled — installing NVIDIA stack"
 
-    # Driver
-    if command -v nvidia-smi &>/dev/null && nvidia-smi &>/dev/null; then
-        ok "NVIDIA drivers already installed"
-        detail "$(nvidia-smi --query-gpu=name,driver_version --format=csv,noheader | head -1)"
-    else
+  # ── NVIDIA drivers ───────────────────────────────────────────────────────────
+  if command -v nvidia-smi &>/dev/null && nvidia-smi &>/dev/null; then
+    ok "NVIDIA drivers already installed"
+    detail "$(nvidia-smi --query-gpu=name,driver_version --format=csv,noheader | head -1)"
+  else
+    case "$PKG_MGR" in
+      apt)
         info "Installing NVIDIA drivers (version: $DRIVER_VERSION)..."
         warn "This may require a reboot before GPU is usable."
         run $SUDO apt-get install -y -qq ubuntu-drivers-common || warn "ubuntu-drivers-common install had warnings"
 
-        # Install nvidia-driver with configured version
         if ! run $SUDO apt-get install -y -qq "nvidia-driver-${DRIVER_VERSION}"; then
-            warn "nvidia-driver-${DRIVER_VERSION} install had warnings"
+          warn "nvidia-driver-${DRIVER_VERSION} install had warnings"
         fi
 
-        # Try nvidia-utils with configured version, fallback to 580-server if unavailable
         if apt-cache show "nvidia-utils-${DRIVER_VERSION}" &>/dev/null 2>&1; then
-            run $SUDO apt-get install -y -qq "nvidia-utils-${DRIVER_VERSION}" || warn "nvidia-utils-${DRIVER_VERSION} install had warnings"
+          run $SUDO apt-get install -y -qq "nvidia-utils-${DRIVER_VERSION}" || warn "nvidia-utils-${DRIVER_VERSION} install had warnings"
         else
-            warn "nvidia-utils-${DRIVER_VERSION} not available, falling back to nvidia-utils-580-server"
-            run $SUDO apt-get install -y -qq nvidia-utils-580-server || warn "nvidia-utils-580-server install had warnings"
+          warn "nvidia-utils-${DRIVER_VERSION} not available, falling back to nvidia-utils-580-server"
+          run $SUDO apt-get install -y -qq nvidia-utils-580-server || warn "nvidia-utils-580-server install had warnings"
         fi
 
         run $SUDO ubuntu-drivers autoinstall || warn "Driver install had warnings — check log"
-        ok "NVIDIA drivers installed"
-
-        echo ""
-        printf "${BLUE}%s${NC}\n" "$(printf '─%.0s' $(seq 1 60))"
-        printf "${BLUE}${BOLD}  NVIDIA drivers installed — reboot required${NC}\n"
-        printf "${BLUE}%s${NC}\n" "$(printf '─%.0s' $(seq 1 60))"
-        echo ""
-        printf "  Would you like to reboot now? ${BOLD}(Y/n)${NC}: "
-        read -r _reboot_choice
-        _reboot_choice="${_reboot_choice:-Y}"
-
-        if [[ "$_reboot_choice" =~ ^[Yy]$ ]]; then
-            echo ""
-            info "After reboot, run: ${BOLD}openmono setup${NC}"
-            echo ""
-            info "Rebooting in 10 seconds (press Ctrl+C to cancel)..."
-            sleep 10
-            $SUDO reboot
-        else
-            err "Reboot cancelled. NVIDIA drivers will not be functional until rebooted."
-            err "Run: sudo reboot"
-            exit 1
+        ;;
+      dnf)
+        info "Installing NVIDIA drivers via rpmfusion..."
+        if ! rpm -q rpmfusion-free-release &>/dev/null 2>&1; then
+          run $SUDO dnf install -y rpmfusion-free-release 2>/dev/null || true
         fi
-    fi
+        if ! rpm -q rpmfusion-nonfree-release &>/dev/null 2>&1; then
+          run $SUDO dnf install -y rpmfusion-nonfree-release 2>/dev/null || true
+        fi
+        run $SUDO dnf install -y akmod-nvidia xorg-x11-drv-nvidia-cuda || warn "NVIDIA driver install had warnings"
+        run $SUDO dnf install -y nvidia-driver nvidia-modprobe 2>/dev/null || true
+        ;;
+      yum)
+        info "Installing NVIDIA drivers via rpmfusion..."
+        if ! rpm -q rpmfusion-free-release &>/dev/null 2>&1; then
+          run $SUDO yum install -y rpmfusion-free-release 2>/dev/null || true
+        fi
+        if ! rpm -q rpmfusion-nonfree-release &>/dev/null 2>&1; then
+          run $SUDO yum install -y rpmfusion-nonfree-release 2>/dev/null || true
+        fi
+        run $SUDO yum install -y akmod-nvidia xorg-x11-drv-nvidia-cuda || warn "NVIDIA driver install had warnings"
+        ;;
+      pacman)
+        info "Installing NVIDIA drivers..."
+        run $SUDO pacman -S --noconfirm nvidia nvidia-utils nvidia-dkms || warn "NVIDIA driver install had warnings"
+        ;;
+      zypper)
+        info "Installing NVIDIA drivers via SUSE NVIDIA repo..."
+        run $SUDO zypper addrepo --refresh https://download.nvidia.com/opensuse/tumbleweed/ NVIDIA 2>/dev/null || true
+        run $SUDO zypper install -y x11-video-nvidiaG06 nvidia-glG06 nvidia-computeG06 || warn "NVIDIA driver install had warnings"
+        ;;
+      *)
+        warn "Cannot auto-install NVIDIA drivers on this distro — install manually"
+        ;;
+    esac
+    ok "NVIDIA drivers installed"
 
-    # CUDA toolkit (optional — pre-built images include CUDA)
-    if command -v nvcc &>/dev/null; then
-        ok "CUDA toolkit already installed"
-        detail "$(nvcc --version | grep release)"
+    echo ""
+    printf "${BLUE}%s${NC}\n" "$(printf '─%.0s' $(seq 1 60))"
+    printf "${BLUE}${BOLD} NVIDIA drivers installed — reboot required${NC}\n"
+    printf "${BLUE}%s${NC}\n" "$(printf '─%.0s' $(seq 1 60))"
+    echo ""
+    printf " Would you like to reboot now? ${BOLD}(Y/n)${NC}: "
+    read -r _reboot_choice
+    _reboot_choice="${_reboot_choice:-Y}"
+
+    if [[ "$_reboot_choice" =~ ^[Yy]$ ]]; then
+      echo ""
+      info "After reboot, run: ${BOLD}openmono setup${NC}"
+      echo ""
+      info "Rebooting in 10 seconds (press Ctrl+C to cancel)..."
+      sleep 10
+      $SUDO reboot
     else
+      err "Reboot cancelled. NVIDIA drivers will not be functional until rebooted."
+      err "Run: sudo reboot"
+      exit 1
+    fi
+  fi
+
+  # ── CUDA toolkit ─────────────────────────────────────────────────────────────
+  if command -v nvcc &>/dev/null; then
+    ok "CUDA toolkit already installed"
+    detail "$(nvcc --version | grep release)"
+  else
+    case "$PKG_MGR" in
+      apt)
         info "Installing nvidia-cuda-toolkit..."
         run $SUDO apt-get install -y -qq nvidia-cuda-toolkit || warn "CUDA toolkit install had warnings (not critical — Docker image includes CUDA)"
-    fi
+        ;;
+      dnf)
+        info "Installing CUDA toolkit via rpmfusion..."
+        run $SUDO dnf install -y cuda 2>/dev/null || warn "CUDA toolkit install had warnings (not critical — Docker image includes CUDA)"
+        ;;
+      yum)
+        info "Installing CUDA toolkit..."
+        run $SUDO yum install -y cuda 2>/dev/null || warn "CUDA toolkit install had warnings (not critical — Docker image includes CUDA)"
+        ;;
+      pacman)
+        info "Installing CUDA toolkit..."
+        run $SUDO pacman -S --noconfirm cuda 2>/dev/null || warn "CUDA toolkit install had warnings (not critical — Docker image includes CUDA)"
+        ;;
+      zypper)
+        info "Installing CUDA toolkit..."
+        run $SUDO zypper install -y cuda 2>/dev/null || warn "CUDA toolkit install had warnings (not critical — Docker image includes CUDA)"
+        ;;
+      *)
+        warn "Cannot auto-install CUDA toolkit — Docker image includes CUDA"
+        ;;
+    esac
+  fi
 
-    # nvidia-container-toolkit (required for Docker GPU passthrough)
-    if dpkg -s nvidia-container-toolkit &>/dev/null 2>&1; then
-        ok "nvidia-container-toolkit already installed"
-    else
-        info "Installing nvidia-container-toolkit..."
+  # ── nvidia-container-toolkit ─────────────────────────────────────────────────
+  if pkg_is_installed nvidia-container-toolkit; then
+    ok "nvidia-container-toolkit already installed"
+  else
+    info "Installing nvidia-container-toolkit..."
+    case "$PKG_MGR" in
+      apt)
         run bash -c 'curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | '"$SUDO"' gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg'
         run bash -c 'curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | sed "s#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g" | '"$SUDO"' tee /etc/apt/sources.list.d/nvidia-container-toolkit.list >/dev/null'
         run $SUDO apt-get update -qq
         run $SUDO apt-get install -y -qq nvidia-container-toolkit || die "Failed to install nvidia-container-toolkit"
-        ok "nvidia-container-toolkit installed"
-    fi
+        ;;
+      dnf|yum)
+        run bash -c 'curl -s -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo | '"$SUDO"' tee /etc/yum.repos.d/nvidia-container-toolkit.repo >/dev/null'
+        run $SUDO "$PKG_MGR" install -y nvidia-container-toolkit || die "Failed to install nvidia-container-toolkit"
+        ;;
+      pacman)
+        # Arch has nvidia-container-toolkit in AUR — try Chaotic-AUR or yay, else warn
+        if command -v yay &>/dev/null; then
+          run yay -S --noconfirm nvidia-container-toolkit || warn "Failed to install nvidia-container-toolkit via AUR"
+        else
+          warn "nvidia-container-toolkit is in AUR — install manually: yay -S nvidia-container-toolkit"
+          warn "Or add the Chaotic-AUR repo: https://chaotic-aur.org/"
+        fi
+        ;;
+      zypper)
+        run $SUDO zypper addrepo --refresh https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo NVIDIA-Container-Toolkit 2>/dev/null || true
+        run $SUDO zypper install -y nvidia-container-toolkit || die "Failed to install nvidia-container-toolkit"
+        ;;
+      *)
+        warn "Cannot auto-install nvidia-container-toolkit — install it manually"
+        warn "See: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html"
+        ;;
+    esac
+    ok "nvidia-container-toolkit installed"
+  fi
 fi
 
 # ── Step 6: Docker ────────────────────────────────────────────────────────────
@@ -270,161 +559,200 @@ step 6 $TOTAL_STEPS "Installing Docker"
 INSTALL_DOCKER_CE=false
 
 if command -v docker &>/dev/null; then
-    # The `docker` command exists — but is it actually functional? On Windows
-    # hosts with Docker Desktop and WSL integration *disabled* for this distro,
-    # `docker` is a shim that errors with "could not be found in this WSL 2
-    # distro" on every invocation. Offer to auto-replace it with native
-    # docker-ce instead of leaving the user to debug.
-    _docker_probe="$(docker version 2>&1 || true)"
-    if echo "$_docker_probe" | grep -qiE "could not be found in this WSL|activate the WSL integration"; then
-        warn "Docker Desktop WSL integration is disabled for this distro."
-        warn "The 'docker' on your PATH is a Docker Desktop shim that won't work"
-        warn "here until you either (a) enable WSL integration in Docker Desktop,"
-        warn "or (b) install native docker-ce in this distro."
-        echo ""
+  _docker_probe="$(docker version 2>&1 || true)"
+  if echo "$_docker_probe" | grep -qiE "could not be found in this WSL|activate the WSL integration"; then
+    warn "Docker Desktop WSL integration is disabled for this distro."
+    warn "The 'docker' on your PATH is a Docker Desktop shim that won't work"
+    warn "here until you either (a) enable WSL integration in Docker Desktop,"
+    warn "or (b) install native docker-ce in this distro."
+    echo ""
 
-        # Default to auto-fix, but let OPENMONO_AUTO_REPLACE_DOCKER=0 or a
-        # terminal prompt opt out. Env-var YES is useful for unattended / CI runs.
-        _reply=""
-        if [ "${OPENMONO_AUTO_REPLACE_DOCKER:-}" = "1" ]; then
-            _reply=y
-            info "OPENMONO_AUTO_REPLACE_DOCKER=1 — installing docker-ce without prompting."
-        elif [ "${OPENMONO_AUTO_REPLACE_DOCKER:-}" = "0" ]; then
-            _reply=n
-        else
-            printf "  Install native docker-ce now? (removes Docker Desktop\n"
-            printf "  integration in THIS WSL distro only — your host install\n"
-            printf "  is untouched.)                                        [Y/n]: "
-            read -r _reply || _reply=Y
-            _reply="${_reply:-Y}"
-        fi
-
-        if [[ "$_reply" =~ ^[Yy] ]]; then
-            info "Removing Docker Desktop WSL shim..."
-            run $SUDO apt-get remove -y docker-desktop 2>/dev/null || true
-            # Whether or not docker-desktop was an apt package, the shim may
-            # exist as a dangling symlink under /usr/bin or /usr/local/bin.
-            # Remove defensively so the docker-ce install can claim the path.
-            run $SUDO rm -f \
-                /usr/bin/docker /usr/bin/docker-compose /usr/bin/docker-credential-desktop \
-                /usr/local/bin/docker /usr/local/bin/docker-compose 2>/dev/null || true
-            hash -r
-            INSTALL_DOCKER_CE=true
-            ok "Docker Desktop shim removed; continuing with docker-ce install"
-        else
-            err "Opted out of auto-install. To fix manually:"
-            err "  a) Docker Desktop → Settings → Resources → WSL Integration"
-            err "     → toggle this distro ON → Apply & Restart, then:"
-            err "       exec bash && openmono setup"
-            err "  b) Or: sudo apt-get remove -y docker-desktop && openmono setup"
-            die "Docker not functional."
-        fi
-    elif ! echo "$_docker_probe" | grep -q "Client:"; then
-        # Command exists, doesn't produce a sensible 'docker version' — probably
-        # daemon isn't running. Give a pointer rather than muddling through.
-        err "Docker command exists but 'docker version' failed:"
-        echo "$_docker_probe" | sed 's/^/  /' >&2
-        die "Fix Docker (start the daemon or reinstall) and re-run openmono setup."
+    _reply=""
+    if [ "${OPENMONO_AUTO_REPLACE_DOCKER:-}" = "1" ]; then
+      _reply=y
+      info "OPENMONO_AUTO_REPLACE_DOCKER=1 — installing docker-ce without prompting."
+    elif [ "${OPENMONO_AUTO_REPLACE_DOCKER:-}" = "0" ]; then
+      _reply=n
     else
-        ok "Docker already installed"
-        detail "$(docker --version)"
+      printf " Install native docker-ce now? (removes Docker Desktop\n"
+      printf " integration in THIS WSL distro only — your host install\n"
+      printf " is untouched.) [Y/n]: "
+      read -r _reply || _reply=Y
+      _reply="${_reply:-Y}"
     fi
+
+    if [[ "$_reply" =~ ^[Yy] ]]; then
+      info "Removing Docker Desktop WSL shim..."
+      case "$PKG_MGR" in
+        apt) run $SUDO apt-get remove -y docker-desktop 2>/dev/null || true ;;
+        dnf|yum) run $SUDO "$PKG_MGR" remove -y docker-desktop 2>/dev/null || true ;;
+        *) run $SUDO rm -f /usr/bin/docker-desktop 2>/dev/null || true ;;
+      esac
+      run $SUDO rm -f \
+        /usr/bin/docker /usr/bin/docker-compose /usr/bin/docker-credential-desktop \
+        /usr/local/bin/docker /usr/local/bin/docker-compose 2>/dev/null || true
+      hash -r
+      INSTALL_DOCKER_CE=true
+      ok "Docker Desktop shim removed; continuing with docker-ce install"
+    else
+      err "Opted out of auto-install. To fix manually:"
+      err " a) Docker Desktop → Settings → Resources → WSL Integration"
+      err " → toggle this distro ON → Apply & Restart, then:"
+      err " exec bash && openmono setup"
+      err " b) Or remove Docker Desktop and install docker-ce, then re-run setup"
+      die "Docker not functional."
+    fi
+  elif ! echo "$_docker_probe" | grep -q "Client:"; then
+    err "Docker command exists but 'docker version' failed:"
+    echo "$_docker_probe" | sed 's/^/ /' >&2
+    die "Fix Docker (start the daemon or reinstall) and re-run openmono setup."
+  else
+    ok "Docker already installed"
+    detail "$(docker --version)"
+  fi
 fi
 
-if [ "$INSTALL_DOCKER_CE" = true ] || ! command -v docker &>/dev/null; then
-    info "Adding Docker's official apt repository..."
-    run $SUDO apt-get install -y -qq ca-certificates gnupg
-    run $SUDO install -m 0755 -d /etc/apt/keyrings
-    if [ ! -f /etc/apt/keyrings/docker.gpg ]; then
+install_docker_ce() {
+  info "Installing Docker CE..."
+  case "$PKG_MGR" in
+    apt)
+      info "Adding Docker's official apt repository..."
+      run $SUDO apt-get install -y -qq ca-certificates gnupg
+      run $SUDO install -m 0755 -d /etc/apt/keyrings
+      if [ ! -f /etc/apt/keyrings/docker.gpg ]; then
         run bash -c 'curl -fsSL https://download.docker.com/linux/ubuntu/gpg | '"$SUDO"' gpg --dearmor -o /etc/apt/keyrings/docker.gpg'
         run $SUDO chmod a+r /etc/apt/keyrings/docker.gpg
-    fi
+      fi
 
-    ARCH="$(dpkg --print-architecture)"
-    CODENAME="$(. /etc/os-release && echo "$VERSION_CODENAME")"
-    run bash -c "echo 'deb [arch=$ARCH signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $CODENAME stable' | $SUDO tee /etc/apt/sources.list.d/docker.list >/dev/null"
+      ARCH="$(dpkg --print-architecture)"
+      CODENAME="$(. /etc/os-release && echo "${VERSION_CODENAME:-$ID}")"
+      run bash -c "echo 'deb [arch=$ARCH signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $CODENAME stable' | $SUDO tee /etc/apt/sources.list.d/docker.list >/dev/null"
 
-    info "Installing Docker packages..."
-    run $SUDO apt-get update -qq
-    run $SUDO apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin \
+      info "Installing Docker packages..."
+      run $SUDO apt-get update -qq
+      run $SUDO apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin \
         || die "Docker install failed"
-    run $SUDO groupadd docker 2>/dev/null || true
-    run $SUDO usermod -aG docker "$USER" || true
-    ok "Docker installed"
+      ;;
+    dnf)
+      info "Adding Docker's official dnf repository..."
+      run $SUDO dnf install -y dnf-plugins-core
+      run $SUDO dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
 
-    # WSL2 doesn't start systemd services by default on some distros — make
-    # sure the docker daemon is actually running before we try to use it.
-    # service(8) works whether or not systemd is PID 1.
-    if command -v service &>/dev/null; then
-        run $SUDO service docker start 2>/dev/null || true
-    fi
-    if command -v systemctl &>/dev/null && systemctl list-unit-files docker.service &>/dev/null 2>&1; then
-        run $SUDO systemctl enable --now docker 2>/dev/null || true
-    fi
+      info "Installing Docker packages..."
+      run $SUDO dnf install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin \
+        || die "Docker install failed"
+      ;;
+    yum)
+      info "Adding Docker's official yum repository..."
+      run $SUDO yum install -y yum-utils
+      run $SUDO yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 
-    # Re-exec this script under 'sg docker' so all remaining steps (and the
-    # subsequent install.sh) run with the docker group active. The user
-    # never needs to manually run 'newgrp docker'. exec replaces the current
-    # process; the re-run is fast because every apt/command check hits the
-    # already-installed branch.
-    if ! docker info &>/dev/null 2>&1 && id -nG 2>/dev/null | grep -qw docker; then
-        if command -v sg &>/dev/null && sg docker -c "docker info" &>/dev/null 2>&1; then
-            info "Re-launching with docker group active (no manual 'newgrp' needed)..."
-            exec sg docker -- bash "$0" "$@"
-        else
-            warn "Docker group added but sg activation failed — a shell restart is needed."
-            warn "After this script completes run ONE of the following, then re-run install.sh:"
-            warn "  1. newgrp docker           (activate in current shell)"
-            warn "  2. exec su -l \$USER       (fresh login shell)"
-            warn "  3. Log out and back in"
-        fi
+      info "Installing Docker packages..."
+      run $SUDO yum install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin \
+        || die "Docker install failed"
+      ;;
+    pacman)
+      info "Installing Docker via pacman..."
+      run $SUDO pacman -S --noconfirm docker docker-compose docker-buildx || die "Docker install failed"
+      ;;
+    zypper)
+      info "Installing Docker via zypper..."
+      run $SUDO zypper install -y docker docker-compose docker-buildkit || die "Docker install failed"
+      ;;
+    *)
+      die "Cannot auto-install Docker on this distro. See: https://docs.docker.com/engine/install/"
+      ;;
+  esac
+
+  run $SUDO groupadd docker 2>/dev/null || true
+  run $SUDO usermod -aG docker "$USER" || true
+  ok "Docker installed"
+
+  if command -v service &>/dev/null; then
+    run $SUDO service docker start 2>/dev/null || true
+  fi
+  if command -v systemctl &>/dev/null && systemctl list-unit-files docker.service &>/dev/null 2>&1; then
+    run $SUDO systemctl enable --now docker 2>/dev/null || true
+  fi
+
+  if ! docker info &>/dev/null 2>&1 && id -nG 2>/dev/null | grep -qw docker; then
+    if command -v sg &>/dev/null && sg docker -c "docker info" &>/dev/null 2>&1; then
+      info "Re-launching with docker group active (no manual 'newgrp' needed)..."
+      exec sg docker -- bash "$0" "$@"
+    else
+      warn "Docker group added but sg activation failed — a shell restart is needed."
+      warn "After this script completes run ONE of the following, then re-run install.sh:"
+      warn " 1. newgrp docker (activate in current shell)"
+      warn " 2. exec su -l \$USER (fresh login shell)"
+      warn " 3. Log out and back in"
     fi
+  fi
+}
+
+if [ "$INSTALL_DOCKER_CE" = true ] || ! command -v docker &>/dev/null; then
+  install_docker_ce
 fi
 
 if docker compose version &>/dev/null 2>&1; then
-    ok "Docker Compose available"
-    detail "$(docker compose version --short 2>/dev/null || echo 'plugin')"
+  ok "Docker Compose available"
+  detail "$(docker compose version --short 2>/dev/null || echo 'plugin')"
 else
-    info "Docker Compose plugin missing — installing..."
-
-    # If Docker was already installed (so we took the "already installed"
-    # branch above), the Docker CE apt repo may not be configured. Add it
-    # now so apt can find docker-compose-plugin.
-    if [ ! -f /etc/apt/sources.list.d/docker.list ]; then
+  info "Docker Compose plugin missing — installing..."
+  case "$PKG_MGR" in
+    apt)
+      if [ ! -f /etc/apt/sources.list.d/docker.list ]; then
         info "Configuring Docker's apt repository first..."
         run $SUDO apt-get install -y -qq ca-certificates gnupg
         run $SUDO install -m 0755 -d /etc/apt/keyrings
         if [ ! -f /etc/apt/keyrings/docker.gpg ]; then
-            run bash -c 'curl -fsSL https://download.docker.com/linux/ubuntu/gpg | '"$SUDO"' gpg --dearmor -o /etc/apt/keyrings/docker.gpg'
-            run $SUDO chmod a+r /etc/apt/keyrings/docker.gpg
+          run bash -c 'curl -fsSL https://download.docker.com/linux/ubuntu/gpg | '"$SUDO"' gpg --dearmor -o /etc/apt/keyrings/docker.gpg'
+          run $SUDO chmod a+r /etc/apt/keyrings/docker.gpg
         fi
         ARCH="$(dpkg --print-architecture)"
-        CODENAME="$(. /etc/os-release && echo "$VERSION_CODENAME")"
+        CODENAME="$(. /etc/os-release && echo "${VERSION_CODENAME:-$ID}")"
         run bash -c "echo 'deb [arch=$ARCH signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $CODENAME stable' | $SUDO tee /etc/apt/sources.list.d/docker.list >/dev/null"
         run $SUDO apt-get update -qq
-    fi
-
-    if run $SUDO apt-get install -y -qq docker-compose-plugin; then
+      fi
+      if run $SUDO apt-get install -y -qq docker-compose-plugin; then
         ok "Docker Compose plugin installed"
-        detail "$(docker compose version --short 2>/dev/null || echo 'plugin')"
-    else
+      else
         warn "apt couldn't install docker-compose-plugin."
         warn "If you're on Docker Desktop (WSL / Mac), enable Compose via the"
         warn "Docker Desktop settings, or update Docker Desktop to a version"
         warn "that bundles the Compose v2 plugin, then re-run this installer."
-    fi
+      fi
+      ;;
+    dnf|yum)
+      run $SUDO "$PKG_MGR" install -y docker-compose-plugin 2>/dev/null \
+        && ok "Docker Compose plugin installed" \
+        || warn "Could not install docker-compose-plugin — install manually"
+      ;;
+    pacman)
+      run $SUDO pacman -S --noconfirm docker-compose 2>/dev/null \
+        && ok "Docker Compose installed" \
+        || warn "Could not install docker-compose — install manually"
+      ;;
+    zypper)
+      run $SUDO zypper install -y docker-compose 2>/dev/null \
+        && ok "Docker Compose installed" \
+        || warn "Could not install docker-compose — install manually"
+      ;;
+    *)
+      warn "Cannot auto-install Docker Compose — install it manually"
+      ;;
+  esac
 fi
 
 # Configure Docker nvidia runtime if GPU detected
 if [ "$HAS_NVIDIA_HW" = true ] && command -v nvidia-ctk &>/dev/null; then
-    if docker info 2>/dev/null | grep -q nvidia; then
-        ok "Docker already configured with nvidia runtime"
-    else
-        info "Configuring Docker with nvidia runtime..."
-        run $SUDO nvidia-ctk runtime configure --runtime=docker
-        run $SUDO systemctl restart docker
-        ok "Docker nvidia runtime configured"
-    fi
+  if docker info 2>/dev/null | grep -q nvidia; then
+    ok "Docker already configured with nvidia runtime"
+  else
+    info "Configuring Docker with nvidia runtime..."
+    run $SUDO nvidia-ctk runtime configure --runtime=docker
+    run $SUDO systemctl restart docker
+    ok "Docker nvidia runtime configured"
+  fi
 fi
 
 # ── Step 7: .NET 10 SDK ──────────────────────────────────────────────────────
@@ -432,32 +760,32 @@ fi
 step 7 $TOTAL_STEPS "Installing .NET 10 SDK"
 
 if command -v dotnet &>/dev/null && dotnet --list-sdks 2>/dev/null | grep -q "^10\."; then
-    ok ".NET 10 SDK already installed"
-    detail "$(dotnet --version)"
+  ok ".NET 10 SDK already installed"
+  detail "$(dotnet --version)"
 else
-    info "Downloading Microsoft dotnet-install script..."
-    run curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
-    chmod +x /tmp/dotnet-install.sh
-    info "Installing .NET 10 to \$HOME/.dotnet (this can take a minute)..."
-    run /tmp/dotnet-install.sh --channel 10.0 --install-dir "$HOME/.dotnet" \
-        || die ".NET install failed"
-    rm -f /tmp/dotnet-install.sh
+  info "Downloading Microsoft dotnet-install script..."
+  run curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+  chmod +x /tmp/dotnet-install.sh
+  info "Installing .NET 10 to \$HOME/.dotnet (this can take a minute)..."
+  run /tmp/dotnet-install.sh --channel 10.0 --install-dir "$HOME/.dotnet" \
+    || die ".NET install failed"
+  rm -f /tmp/dotnet-install.sh
 
-    export DOTNET_ROOT="$HOME/.dotnet"
-    export PATH="$DOTNET_ROOT:$PATH"
+  export DOTNET_ROOT="$HOME/.dotnet"
+  export PATH="$DOTNET_ROOT:$PATH"
 
-    for rc in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
-        if [ -f "$rc" ] && ! grep -q "DOTNET_ROOT" "$rc"; then
-            {
-                echo ""
-                echo "# .NET SDK"
-                echo 'export DOTNET_ROOT="$HOME/.dotnet"'
-                echo 'export PATH="$DOTNET_ROOT:$PATH"'
-            } >> "$rc"
-            detail "Added .NET to PATH in $(basename "$rc")"
-        fi
-    done
-    ok ".NET 10 SDK installed ($(dotnet --version 2>/dev/null || echo 'reload shell'))"
+  for rc in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
+    if [ -f "$rc" ] && ! grep -q "DOTNET_ROOT" "$rc"; then
+      {
+        echo ""
+        echo "# .NET SDK"
+        echo 'export DOTNET_ROOT="$HOME/.dotnet"'
+        echo 'export PATH="$DOTNET_ROOT:$PATH"'
+      } >> "$rc"
+      detail "Added .NET to PATH in $(basename "$rc")"
+    fi
+  done
+  ok ".NET 10 SDK installed ($(dotnet --version 2>/dev/null || echo 'reload shell'))"
 fi
 
 # ── Step 8: Summary ──────────────────────────────────────────────────────────
@@ -465,12 +793,12 @@ fi
 step 8 $TOTAL_STEPS "Verifying install"
 
 check_installed() {
-    local cmd="$1"
-    if command -v "$cmd" &>/dev/null; then
-        printf "  ${GREEN}✓${NC} %s\n" "$cmd"
-    else
-        printf "  ${YELLOW}…${NC} %s (may need shell reload)\n" "$cmd"
-    fi
+  local cmd="$1"
+  if command -v "$cmd" &>/dev/null; then
+    printf " ${GREEN}✓${NC} %s\n" "$cmd"
+  else
+    printf " ${YELLOW}…${NC} %s (may need shell reload)\n" "$cmd"
+  fi
 }
 
 check_installed docker
@@ -481,37 +809,36 @@ check_installed curl
 check_installed rg
 check_installed dotnet
 if [ "$HAS_NVIDIA_HW" = true ]; then
-    check_installed nvidia-ctk
-    check_installed nvidia-smi
+  check_installed nvidia-ctk
+  check_installed nvidia-smi
 fi
 
-# Check if docker is accessible without sudo
 DOCKER_NEEDS_GROUP=false
 if command -v docker &>/dev/null; then
-    if ! docker info &>/dev/null 2>&1; then
-        DOCKER_NEEDS_GROUP=true
-    fi
+  if ! docker info &>/dev/null 2>&1; then
+    DOCKER_NEEDS_GROUP=true
+  fi
 fi
 
 echo ""
 ok "Prerequisites ready"
 
 if [ "$DOCKER_NEEDS_GROUP" = true ]; then
-    echo ""
-    printf "${YELLOW}%s${NC}\n" "$(printf '─%.0s' $(seq 1 60))"
-    printf "${YELLOW}${BOLD}  Docker Group Activation Required${NC}\n"
-    printf "${YELLOW}%s${NC}\n" "$(printf '─%.0s' $(seq 1 60))"
-    echo ""
-    echo "  The 'sg' command could not activate the docker group automatically."
-    echo "  Run ONE of the following before running install.sh:"
-    echo ""
-    echo "    ${BOLD}newgrp docker${NC}              # Activate in current shell"
-    echo "    ${BOLD}exec su -l \$USER${NC}          # Start fresh login shell"
-    echo "    ${BOLD}Log out and back in${NC}        # Full session refresh"
-    echo ""
-    echo "  After activation, verify with: docker info"
-    echo "  Then run: ./scripts/install.sh"
-    echo ""
+  echo ""
+  printf "${YELLOW}%s${NC}\n" "$(printf '─%.0s' $(seq 1 60))"
+  printf "${YELLOW}${BOLD} Docker Group Activation Required${NC}\n"
+  printf "${YELLOW}%s${NC}\n" "$(printf '─%.0s' $(seq 1 60))"
+  echo ""
+  echo " The 'sg' command could not activate the docker group automatically."
+  echo " Run ONE of the following before running install.sh:"
+  echo ""
+  echo " ${BOLD}newgrp docker${NC} # Activate in current shell"
+  echo " ${BOLD}exec su -l \$USER${NC} # Start fresh login shell"
+  echo " ${BOLD}Log out and back in${NC} # Full session refresh"
+  echo ""
+  echo " After activation, verify with: docker info"
+  echo " Then run: ./scripts/install.sh"
+  echo ""
 fi
 
 show_log_location


### PR DESCRIPTION
Fixes #13 

## Summary

The prerequisite installer (`scripts/install_prereqs.sh`) was Ubuntu-only, hardcoding `apt-get`/`dpkg` for all package operations. Running `openmono setup` on Fedora 43 (or any non-Debian distro) would fail at step 3 ("Updating apt package index") and display a warning that the script "targets Ubuntu."

This PR rewrites the Linux prerequisite installer to detect and use the system's native package manager, following the same pattern already used by the macOS scripts (`install_prereqs_macos.sh` / `install_macos.sh`).

## Changes

### `scripts/install_prereqs.sh` (major rewrite)
- **OS detection**: Accepts `ubuntu`, `debian`, `fedora`, `rhel`, `centos`, `rocky`, `almalinux`, `arch`, `manjaro`, `opensuse-tumbleweed`, `opensuse-leap`, `suse` (via `$ID` / `$ID_LIKE` from `/etc/os-release`)
- **Package manager detection**: Auto-detects `dnf`, `yum`, `apt`, `pacman`, or `zypper` and dispatches all package operations through `pkg_update()`, `install_pkg()`, and `pkg_is_installed()` helpers
- **Distro-adaptive package names**: Maps build essentials (`build-essential` → `@development-tools` → `base-devel` → `devel_basis`), OpenBLAS (`libopenblas-dev` → `openblas-devel` → `openblas` → `libopenblas-devel`), pip, pciutils, etc.
- **Docker CE**: Adds Docker's official repo for each distro (apt, dnf, yum) or uses native packages (pacman, zypper)
- **NVIDIA drivers**: Fedora/rpmfusion (`akmod-nvidia`), Arch (`nvidia-dkms`), openSUSE (`x11-video-nvidiaG06`), plus existing Ubuntu path
- **nvidia-container-toolkit**: Adds rpm repo path (Fedora/RHEL/openSUSE), AUR note (Arch), alongside existing deb repo path
- **CUDA toolkit**: Distro-appropriate packages where available; all paths fall back gracefully since Docker images include CUDA

### `scripts/install.sh`
- Replaced `dpkg -s nvidia-container-toolkit` check with cross-distro `pkg_is_installed()` helper (probes dpkg/rpm/pacman/zypper)

### `openmono` (CLI)
- Replaced hardcoded `sudo apt install jq` error message with dynamic package manager detection

### `get-openmono.sh` (bootstrap installer)
- Replaced hardcoded `sudo apt install` error messages with distro-aware `pkg_install_hint()` function

## Tested on
- **Fedora 43** — `openmono setup` now completes all 8 prerequisite steps
- **Ubuntu 24.04** — Existing apt path is unchanged and still works
- Syntax-checked (`bash -n`) on all modified scripts

## What this does NOT change
- `scripts/install.sh` and `scripts/install_macos.sh` — these are already mostly distro-agnostic (they use Docker, pip, and curl rather than system packages)
- The macOS scripts — no changes needed