### PR TITLE
added api key into client context

### DIFF
--- a/src/OpenMono.Cli/Tools/AgentTool.cs
+++ b/src/OpenMono.Cli/Tools/AgentTool.cs
@@ -61,7 +61,7 @@ public sealed class AgentTool : ToolBase
             MaxTokens = context.Config.Llm.MaxOutputTokens,
         };
 
-        var llm = new OpenAiCompatClient(context.Config.Llm);
+        var llm = new OpenAiCompatClient(context.Config.Llm) { ApiKey = context.Config.Llm.ApiKey };
         var completedNormally = false;
 
         try


### PR DESCRIPTION
Sub-agents failing when connected to llama-server with api key in place. 
Fixed by adding api key from config context