### PR TITLE
Fix/agent user

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -30,6 +30,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
+RUN mkdir -p /home/agent && chmod 1777 /home/agent
+
 # Install code-review-graph for structural code analysis (MCP server)
 RUN pip3 install --no-cache-dir --break-system-packages code-review-graph
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -43,10 +43,11 @@ services:
     profiles: ["full", "agent"]
     volumes:
       - ${WORKSPACE:-.}:/workspace
-      - ${HOME}/.openmono:/root/.openmono
-      - ${HOME}/.code-review-graph:/root/.code-review-graph
+      - ${HOME}/.openmono:/home/agent/.openmono
+      - ${HOME}/.code-review-graph:/home/agent/.code-review-graph
       - ../ref:/ref:ro
     environment:
+      - HOME=/home/agent
       - OPENMONO_ENDPOINT=${OPENMONO_ENDPOINT:-http://llama-server:7474}
       - OPENMONO_WORKSPACE=/workspace
       - OPENMONO_HOST_WORKSPACE=${WORKSPACE:-.}

--- a/docker/openmono-wrapper.sh
+++ b/docker/openmono-wrapper.sh
@@ -16,7 +16,8 @@ DOCKER_ARGS=(
   --interactive
   --tty
   -v "${WORKSPACE}:/workspace"
-  -v "${CONFIG_DIR}:/root/.openmono"
+  -v "${CONFIG_DIR}:/home/agent/.openmono"
+  -e "HOME=/home/agent"
   -e "OPENMONO_IN_CONTAINER=1"
 )
 

--- a/openmono
+++ b/openmono
@@ -535,6 +535,7 @@ cmd_agent() {
     fi
 
     docker compose run --rm \
+        --user "$(id -u):$(id -g)" \
         -e WORKSPACE="$WORKSPACE" \
         -e LLAMA_PORT="$LLAMA_PORT" \
         agent "$@"

--- a/openmono
+++ b/openmono
@@ -536,6 +536,7 @@ cmd_agent() {
 
     docker compose run --rm \
         --user "$(id -u):$(id -g)" \
+        -e HOME=/home/agent \
         -e WORKSPACE="$WORKSPACE" \
         -e LLAMA_PORT="$LLAMA_PORT" \
         agent "$@"


### PR DESCRIPTION
1. File operations in the agent container ran as root which resulted in files created by the agent to be owned by root on the host.
    > Set user in container with matching UID/GID as the user running the agent.

2.  Mounting `.openmono` and `.code-review-graph` in the container at `/root/*` made them inaccessible. 
    > Created `/home/agent` path inside the container. Set `HOME=/home/agent` to make them accessible to non-root user.