### PR TITLE
fix: persist completed tool results when a batch pauses for permission

### DIFF
--- a/src/OpenMono.Cli/Session/ConversationLoop.cs
+++ b/src/OpenMono.Cli/Session/ConversationLoop.cs
@@ -911,6 +911,7 @@ public sealed class ConversationLoop : IDisposable
             {
                 // User interaction pending (permission, input, etc.) — propagate to turn runner to pause
                 Log.Info($"[PENDING_RESPONSE] Tool {call.Name} paused for user response — re-throwing to turn runner");
+                await PersistCompletedToolResultsAsync(toolCalls, results, ct);
                 throw;
             }
             catch (OperationCanceledException) when (siblingAbortCts.IsCancellationRequested && !ct.IsCancellationRequested)
@@ -943,11 +944,50 @@ public sealed class ConversationLoop : IDisposable
             {
                 // User interaction pending (permission, input, etc.) — propagate to turn runner to pause
                 Log.Info($"[PENDING_RESPONSE] Tool {item.Call.Name} paused for user response — re-throwing to turn runner");
+                await PersistCompletedToolResultsAsync(toolCalls, results, ct);
                 throw;
             }
         }
 
         return [.. results];
+    }
+
+    /// <summary>
+    /// A pause (permission / user input) aborts the current batch mid-way, before the
+    /// normal result-append loop runs. Persist the results that already completed so the
+    /// resume path (ResolvePendingToolCallsAsync) sees them as answered and re-executes
+    /// only the still-pending calls — an already-executed write must never run twice.
+    /// </summary>
+    private async Task PersistCompletedToolResultsAsync(
+        List<ToolCall> toolCalls, ToolResult[] results, CancellationToken ct)
+    {
+        foreach (var (call, result) in toolCalls.Zip(results))
+        {
+            if (result is null) continue;
+
+            var content = result.Content;
+            if (content.Length > LargeResultThreshold)
+            {
+                var refPath = await StoreContentReplacementAsync(call.Name, content, ct);
+                content = $"[Result truncated — {content.Length} chars. Full output stored at: {refPath}]\n" +
+                          content[..Math.Min(2000, content.Length)] + "\n... (truncated)";
+            }
+
+            _session.AddMessage(new Message
+            {
+                Role = MessageRole.Tool,
+                ToolCallId = call.Id,
+                ToolName = call.Name,
+                Content = content,
+                IsError = result.IsError,
+            });
+
+            if (_sink is not null)
+            {
+                var artifactId = result.Artifacts.Count > 0 ? result.Artifacts[0].Id : null;
+                await _sink.OnToolResultPreviewAsync(call.Id, result.ModelPreview, artifactId);
+            }
+        }
     }
 
     private ToolContext BuildToolContext() => new()

--- a/src/OpenMono.Tests/Acp/AcpTurnRunnerTests.cs
+++ b/src/OpenMono.Tests/Acp/AcpTurnRunnerTests.cs
@@ -618,6 +618,62 @@ public sealed class AcpTurnRunnerTests
 
 
 
+    [Fact]
+    public async Task Pause_persists_completed_sibling_results_so_resume_never_reexecutes_them()
+    {
+        var tools = new ToolRegistry();
+        var counting = new CountingTool();
+        var asking = new AskingTool();
+        tools.Register(counting);
+        tools.Register(asking);
+
+        // One assistant message, two sequential (writeable) calls: the first auto-executes,
+        // the second pauses for permission mid-batch.
+        var (runner, session, _) = BuildHarness(
+            tools: tools,
+            llmRounds: new List<List<StreamChunk>>
+            {
+                new()
+                {
+                    new() { ToolCallDelta = new ToolCall { Id = "call_a", Name = "CountingTool", Arguments = "{}" }, IsComplete = false },
+                    new() { ToolCallDelta = new ToolCall { Id = "call_b", Name = "AskingTool", Arguments = "{}" }, IsComplete = false },
+                    new() { IsComplete = true },
+                },
+                new() { new() { TextDelta = "done.", IsComplete = false }, new() { IsComplete = true, Usage = new UsageInfo() } },
+            });
+
+        await runner.RunUserMessageAsync("run both", CancellationToken.None);
+
+        counting.ExecuteCount.Should().Be(1);
+        session.Messages.Should().Contain(m => m.Role == MessageRole.Tool && m.ToolCallId == "call_a",
+            "the completed first call must be persisted when the batch pauses, or the resume re-executes it");
+
+        var pauseId = session.PendingIds.Single();
+        using var payload = JsonDocument.Parse($"{{\"id\":\"{pauseId}\",\"decision\":\"allow\"}}");
+        await runner.ResumeWithPermissionAsync(payload.RootElement, CancellationToken.None);
+
+        counting.ExecuteCount.Should().Be(1, "an already-executed write must never run twice across a pause");
+        asking.ExecuteCount.Should().Be(1);
+        session.Messages.Count(m => m.Role == MessageRole.Tool && m.ToolCallId == "call_a").Should().Be(1);
+        session.Messages.Count(m => m.Role == MessageRole.Tool && m.ToolCallId == "call_b").Should().Be(1);
+    }
+
+    private sealed class CountingTool : ITool
+    {
+        public string Name => "CountingTool";
+        public string Description => "Executes without prompting and counts invocations";
+        public bool IsConcurrencySafe => false;
+        public bool IsReadOnly => false;
+        public JsonElement InputSchema { get; } = JsonDocument.Parse("""{"type":"object"}""").RootElement.Clone();
+        public PermissionLevel RequiredPermission(JsonElement input) => PermissionLevel.AutoAllow;
+        public int ExecuteCount { get; private set; }
+        public Task<ToolResult> ExecuteAsync(JsonElement input, ToolContext ctx, CancellationToken ct)
+        {
+            ExecuteCount++;
+            return Task.FromResult(ToolResult.Success("counted"));
+        }
+    }
+
     private sealed class AskingTool : ITool
     {
         public string Name => "AskingTool";


### PR DESCRIPTION
## Problem
When one assistant message carries several tool calls and a later call pauses for permission, the results of calls that already executed are dropped: the pause aborts the batch before the result-append loop runs. On resume, `ResolvePendingToolCallsAsync` treats those calls as unanswered and executes them again. For write tools (Bash, FileWrite, FileEdit) that is a real double execution — e.g. an appending shell command runs twice.

## Fix
On `PendingUserResponseException`, append the already-completed results as Tool messages before re-throwing (both in the parallel-await loop and the sequential loop). The existing resume path skips answered call ids, so only the genuinely pending calls execute. No behaviour change for single-call batches.

## Test
`Pause_persists_completed_sibling_results_so_resume_never_reexecutes_them` — two sequential writeable calls in one assistant message, the first auto-allowed, the second asking for permission: the first must execute exactly once across the pause and its result must survive.

Found while benchmarking four local models through the headless ACP agent, where mid-batch pauses happen constantly. Note: the 4 test failures on current main (3x PlaybookLoader, 1x New_acp_session_defaults_to_plan_mode) are pre-existing and unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)