### PR TITLE
fix: mode banner stacked into the session on every LLM call

### DIFF
--- a/src/OpenMono.Cli/Session/ConversationLoop.cs
+++ b/src/OpenMono.Cli/Session/ConversationLoop.cs
@@ -340,6 +340,10 @@ public sealed class ConversationLoop : IDisposable
             // nothing about the current mode. Both Plan and Build get a banner so the model
             // never infers its mode or parrots a stale "I'm in plan mode" from history.
             {
+                // BuildContextWindow may return the session's live message list; mutate a copy,
+                // or the banner is persisted and stacks up on every iteration — which also
+                // shifts the prompt prefix each call and defeats llama.cpp's KV cache.
+                contextWindow = new List<Message>(contextWindow);
                 var sysIdx = contextWindow.FindIndex(m => m.Role == MessageRole.System);
                 if (sysIdx >= 0)
                 {

--- a/src/OpenMono.Tests/Acp/AcpTurnRunnerTests.cs
+++ b/src/OpenMono.Tests/Acp/AcpTurnRunnerTests.cs
@@ -618,6 +618,46 @@ public sealed class AcpTurnRunnerTests
 
 
 
+    [Fact]
+    public async Task Mode_banner_is_ephemeral_and_never_persisted_into_the_session()
+    {
+        var tools = new ToolRegistry();
+        tools.Register(new NoopTool());
+
+        // Two LLM rounds in one turn: tool call, then final text — the banner is
+        // prepended per iteration and must not accumulate in the stored system message.
+        var (runner, session, _) = BuildHarness(
+            tools: tools,
+            llmRounds: new List<List<StreamChunk>>
+            {
+                new()
+                {
+                    new() { ToolCallDelta = new ToolCall { Id = "call_1", Name = "NoopTool", Arguments = "{}" }, IsComplete = false },
+                    new() { IsComplete = true },
+                },
+                new() { new() { TextDelta = "done.", IsComplete = false }, new() { IsComplete = true, Usage = new UsageInfo() } },
+            });
+
+        await runner.RunUserMessageAsync("go", CancellationToken.None);
+
+        var system = session.Messages.First(m => m.Role == MessageRole.System);
+        system.Content.Should().NotContain("ACTIVE MODE",
+            "the per-turn mode banner must stay ephemeral; persisting it stacks a copy per LLM call, " +
+            "growing the prompt and shifting its prefix so llama.cpp's KV cache never hits");
+    }
+
+    private sealed class NoopTool : ITool
+    {
+        public string Name => "NoopTool";
+        public string Description => "Executes without prompting";
+        public bool IsConcurrencySafe => false;
+        public bool IsReadOnly => true;
+        public JsonElement InputSchema { get; } = JsonDocument.Parse("""{"type":"object"}""").RootElement.Clone();
+        public PermissionLevel RequiredPermission(JsonElement input) => PermissionLevel.AutoAllow;
+        public Task<ToolResult> ExecuteAsync(JsonElement input, ToolContext ctx, CancellationToken ct)
+            => Task.FromResult(ToolResult.Success("ok"));
+    }
+
     private sealed class AskingTool : ITool
     {
         public string Name => "AskingTool";


### PR DESCRIPTION
BuildContextWindow returns the session's live message list when no checkpoint exists. Prepending the per-turn mode banner replaced the system message in that list, so every loop iteration added another banner copy — despite the comment calling it 'ephemeral, not persisted'.

Effects, measured against llama-server: the prompt grows ~350 tokens per LLM call, and because the added copy lands at the START of the system message the prompt prefix shifts every call, so the KV cache never hits. Each call reprocessed the full 13k+ token prompt (75-100s at Vulkan iGPU speeds) instead of ~100 new tokens. Agent tasks that take ~160s ran into 20-minute budgets.

Mutate a copy of the context window instead. After the fix the system message is byte-identical across calls (verified by capturing the requests) and llama-server reports ~100-token prompt evals on follow-up calls.

Test proves the banner stays out of the stored session; it fails on main.