### PR TITLE
Support fully OSS agent + model setup without Docker (native fallback)

### DIFF
--- a/openmono
+++ b/openmono
@@ -794,6 +794,37 @@ _clipboard_bridge_stop() {
 }
 
 cmd_agent() {
+    # Native / no-Docker fallback for fully open-source dev, cloud, agent-only,
+    # or any environment without Docker. Uses the published OSS .NET agent binary
+    # (or dotnet run from source) + the settings configured via `openmono config`.
+    # This keeps everything 100% open source (mock or real llama.cpp OSS model).
+    if ! docker info &>/dev/null 2>&1; then
+        info "Docker not available — running native open-source agent"
+        WORKSPACE="${WORKSPACE:-$(pwd)}"
+        export WORKSPACE
+        mkdir -p "${HOME}/.openmono"
+
+        local settings="$HOME/.openmono/settings.json"
+        local cfg_endpoint cfg_key
+        if [[ -f "$settings" ]] && command -v jq &>/dev/null; then
+            cfg_endpoint=$(jq -r '.llm.endpoint // empty' "$settings")
+            cfg_key=$(jq -r '.llm.api_key // empty' "$settings")
+            [[ -n "$cfg_key" ]] && export OPENMONO_API_KEY="$cfg_key"
+        fi
+        if [[ -z "${cfg_endpoint}" ]]; then
+            cfg_endpoint="http://localhost:7474"
+        fi
+        export OPENMONO_ENDPOINT="$cfg_endpoint"
+
+        # Prefer the stable published native build we created during setup
+        if [[ -x "$HOME/.openmono/bin/openmono" ]]; then
+            exec "$HOME/.openmono/bin/openmono" "$@"
+        fi
+        # Fallback to source (dev in the OpenMono tree)
+        cd "$REPO_DIR"
+        exec dotnet run --project src/OpenMono.Cli -- "$@"
+    fi
+
     _ensure_docker
     WORKSPACE="${WORKSPACE:-$(pwd)}"
     export WORKSPACE


### PR DESCRIPTION
Re-opening this contribution (previously #102, which got closed and had drifted 35 commits behind main) rebased cleanly onto current `main`.

## What
`cmd_agent` now detects a missing Docker daemon and falls back to running the native published agent binary (or `dotnet run` from source) against the configured `llm.endpoint`/`llm.model`, enabling agent-only, cloud-dev, and Docker-restricted environments to run a fully open-source stack (mock model or real community GGUF via llama.cpp).

## Why
Docker is not available in every dev/CI/cloud-agent environment. This lets `openmono agent` work anywhere with just the .NET runtime + an OpenAI-compatible endpoint.

## Diff
Rebased onto current `main` — the diff is now a focused 31-line addition to `cmd_agent()` in the `openmono` launcher script. (The rest of the original PR's described setup steps were local machine configuration, not repo changes, so nothing else needed to move.)

## Tested
Verified locally: `openmono agent` with Docker unavailable falls through to the native binary, loads OSS config, and reaches a mock `/v1/chat/completions` endpoint successfully.

Made with [Cursor](https://cursor.com)