### PR TITLE
added report-ctx flag for playbooks / added ctx recorder

### DIFF
--- a/src/OpenMono.Cli/Llm/ILlmClient.cs
+++ b/src/OpenMono.Cli/Llm/ILlmClient.cs
@@ -41,6 +41,11 @@ public sealed record UsageInfo
     public int CompletionTokens { get; init; }
     public int TotalTokens => PromptTokens + CompletionTokens;
 
+    /// <summary>Tokens served from llama.cpp's KV cache (prompt_tokens_details.cached_tokens).
+    /// These were NOT freshly reprocessed — they were reused from a prior request's cached prefix.
+    /// Informational for context accounting: freshly-processed tokens ≈ PromptTokens - CachedTokens.</summary>
+    public int CachedTokens { get; init; }
+
     // Generation throughput from llama.cpp's `timings` block (when present on the response).
     // PredictedTokens/PredictedMs are accumulated for a rolling average; PredictedPerSecond is
     // the server's own live decode rate for this turn. All default to 0 on providers that omit timings.

--- a/src/OpenMono.Cli/Llm/OpenAiCompatClient.cs
+++ b/src/OpenMono.Cli/Llm/OpenAiCompatClient.cs
@@ -304,11 +304,13 @@ public sealed class OpenAiCompatClient : ILlmClient, IDisposable
                         {
                             PromptTokens = usageEl.TryGetProperty("prompt_tokens", out var pt) ? pt.GetInt32() : 0,
                             CompletionTokens = usageEl.TryGetProperty("completion_tokens", out var cpt) ? cpt.GetInt32() : 0,
+                            CachedTokens = usageEl.TryGetProperty("prompt_tokens_details", out var ptd) && ptd.ValueKind == JsonValueKind.Object
+                                && ptd.TryGetProperty("cached_tokens", out var ctdel) ? ctdel.GetInt32() : 0,
                             PredictedTokens = predictedN,
                             PredictedMs = predictedMs,
                             PredictedPerSecond = predictedPerSec,
                         };
-                        var usageMsg = $"[SSE] usage: prompt={usage.PromptTokens} completion={usage.CompletionTokens} total={usage.TotalTokens} gen_tps={usage.PredictedPerSecond:F1}";
+                        var usageMsg = $"[SSE] usage: prompt={usage.PromptTokens} completion={usage.CompletionTokens} cached={usage.CachedTokens} total={usage.TotalTokens} gen_tps={usage.PredictedPerSecond:F1}";
                         OnDebug?.Invoke(usageMsg);
                         Log.Info(usageMsg);
                     }

--- a/src/OpenMono.Cli/Playbooks/ContextUsageRecorder.cs
+++ b/src/OpenMono.Cli/Playbooks/ContextUsageRecorder.cs
@@ -1,0 +1,233 @@
+using System.Text;
+using System.Text.Json;
+
+namespace OpenMono.Playbooks;
+
+/// <summary>Source of a recorded LLM call inside a playbook run: the step's own tool loop, an
+/// output-schema JSON correction, or a worker-initiated repair turn (reserved; playbooks capture
+/// the first two today).</summary>
+public enum ContextCallSource { Step, JsonCorrection, Repair }
+
+/// <summary>A tool invocation issued by a single LLM request (Bash command, FileRead path, etc.).</summary>
+public sealed record ContextToolCall
+{
+    public string Name { get; init; } = "";
+    public string Command { get; init; } = "";
+}
+
+/// <summary>One LLM request's actual token usage, as reported by the provider (llama.cpp via
+/// OpenAI-compat). Real per-request numbers (not estimates). A request may issue 0..N tool calls,
+/// listed in <see cref="Tools"/>.</summary>
+public sealed record ContextCall
+{
+    public string Step { get; init; } = "";
+    public int Index { get; init; }
+    public ContextCallSource Source { get; init; }
+    public int PromptTokens { get; init; }
+    public int CompletionTokens { get; init; }
+    public int CachedTokens { get; init; }
+    public List<ContextToolCall> Tools { get; init; } = [];
+
+    public int FreshTokens => Math.Max(0, PromptTokens - CachedTokens);
+    public int TotalTokens => PromptTokens + CompletionTokens;
+}
+
+/// <summary>Rolled-up context usage for one playbook step (aggregate of its calls).</summary>
+public sealed record ContextStep
+{
+    public string Step { get; init; } = "";
+    public int PromptTokens { get; init; }
+    public int CompletionTokens { get; init; }
+    public int CachedTokens { get; init; }
+    public int PeakPrompt { get; init; }
+    public int CallCount { get; init; }
+    public List<ContextCall> Calls { get; init; } = [];
+
+    public int FreshTokens => Math.Max(0, PromptTokens - CachedTokens);
+    public int TotalTokens => PromptTokens + CompletionTokens;
+}
+
+/// <summary>Accumulates actual LLM context usage during a playbook run. When <see cref="Active"/> is
+/// true (playbook declares <c>report_ctx: true</c>) each completed run appends one JSON object to
+/// <c>.openmono/data/ctx-usage.jsonl</c> (JSONL, append-only) so every run's full history is retained.
+/// Not thread-safe; used by a single playbook execution.</summary>
+public sealed class ContextUsageRecorder
+{
+    public const string FileName = "ctx-usage.jsonl";
+
+    private readonly List<ContextCall> _calls = [];
+    private readonly List<ContextStep> _steps = [];
+    private int _run;
+    private int _stepIndex;
+
+    public bool Active { get; }
+    public string Playbook { get; }
+    public string SessionId { get; }
+    public DateTime StartedAt { get; }
+
+    /// <summary>True until the run completes normally. Set false by the executor on the normal-completion
+    /// path so aborted runs (doom loop, gate, script failure, exception) are identifiable in the report.</summary>
+    public bool Aborted { get; set; } = true;
+
+    public ContextUsageRecorder(string playbook, string sessionId, string dataDirectory, bool active)
+    {
+        Playbook = playbook;
+        SessionId = sessionId;
+        Active = active;
+        StartedAt = DateTime.UtcNow;
+        if (active)
+            _run = ComputeNextRun(dataDirectory);
+    }
+
+    private static int ComputeNextRun(string dataDirectory)
+    {
+        var filePath = CtxFilePath(dataDirectory);
+        if (!File.Exists(filePath)) return 1;
+
+        var max = 0;
+        try
+        {
+            foreach (var line in File.ReadLines(filePath))
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                using var doc = JsonDocument.Parse(line);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("run", out var runEl) && runEl.TryGetInt32(out var n) && n > max)
+                    max = n;
+            }
+        }
+        catch
+        {
+            // Best-effort: on any parse failure, fall back to a run of 1.
+            return 1;
+        }
+        return max + 1;
+    }
+
+    /// <summary>Starts a new step bucket. Returns false (and records nothing) when not active.</summary>
+    public void BeginStep(string stepId) => _stepIndex = 0;
+
+    /// <summary>Records a single LLM call's usage under the current step. No-op when not active.
+    /// <paramref name="tools"/> lists the tool invocations that request issued (name + command).</summary>
+    public void Record(string stepId, ContextCallSource source, int promptTokens, int completionTokens, int cachedTokens,
+        IEnumerable<ContextToolCall>? tools = null)
+    {
+        if (!Active || promptTokens < 0 || completionTokens < 0) return;
+        _calls.Add(new ContextCall
+        {
+            Step = stepId,
+            Index = _stepIndex++,
+            Source = source,
+            PromptTokens = promptTokens,
+            CompletionTokens = completionTokens,
+            CachedTokens = cachedTokens,
+            Tools = tools?.ToList() ?? [],
+        });
+    }
+
+    /// <summary>Closes the current step, rolling up its calls into <see cref="ContextStep"/>.</summary>
+    public void CompleteStep(string stepId)
+    {
+        if (!Active) return;
+        var calls = _calls.Where(c => c.Step == stepId).ToList();
+        if (calls.Count == 0) return;
+
+        _steps.Add(new ContextStep
+        {
+            Step = stepId,
+            PromptTokens = calls.Sum(c => c.PromptTokens),
+            CompletionTokens = calls.Sum(c => c.CompletionTokens),
+            CachedTokens = calls.Sum(c => c.CachedTokens),
+            PeakPrompt = calls.Count > 0 ? calls.Max(c => c.PromptTokens) : 0,
+            CallCount = calls.Count,
+            Calls = calls,
+        });
+    }
+
+    /// <summary>Appends the run's record as one JSON line to ctx-usage.jsonl. No-op when not active.</summary>
+    public void Flush(string dataDirectory)
+    {
+        if (!Active) return;
+
+        var allCalls = _calls.ToList();
+        var repairCalls = allCalls.Where(c => c.Source == ContextCallSource.Repair).ToList();
+        var stepRecords = _steps.Select(s => new
+        {
+            s.Step,
+            prompt_tokens = s.PromptTokens,
+            completion_tokens = s.CompletionTokens,
+            cached_tokens = s.CachedTokens,
+            peak_prompt = s.PeakPrompt,
+            total_tokens = s.TotalTokens,
+            fresh_tokens = s.FreshTokens,
+            call_count = s.CallCount,
+            calls = s.Calls.Select(c => CallRecord(c)).ToList(),
+        }).ToList();
+
+        var runRecord = new
+        {
+            run = _run,
+            playbook = Playbook,
+            session_id = SessionId,
+            started_at = StartedAt.ToString("O"),
+            report_ctx = true,
+            aborted = Aborted,
+            steps = stepRecords,
+            repair = repairCalls.Count > 0 ? new
+            {
+                call_count = repairCalls.Count,
+                prompt_tokens = repairCalls.Sum(c => c.PromptTokens),
+                completion_tokens = repairCalls.Sum(c => c.CompletionTokens),
+                cached_tokens = repairCalls.Sum(c => c.CachedTokens),
+                total_tokens = repairCalls.Sum(c => c.TotalTokens),
+                fresh_tokens = repairCalls.Sum(c => c.FreshTokens),
+            } : null,
+            totals = new
+            {
+                prompt_tokens = allCalls.Sum(c => c.PromptTokens),
+                completion_tokens = allCalls.Sum(c => c.CompletionTokens),
+                cached_tokens = allCalls.Sum(c => c.CachedTokens),
+                peak_prompt = allCalls.Count > 0 ? allCalls.Max(c => c.PromptTokens) : 0,
+                total_tokens = allCalls.Sum(c => c.TotalTokens),
+                fresh_tokens = allCalls.Sum(c => c.FreshTokens),
+                call_count = allCalls.Count,
+            },
+        };
+
+        try
+        {
+            var filePath = CtxFilePath(dataDirectory);
+            var dir = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+            var line = JsonSerializer.Serialize(runRecord, JsonOptions);
+            File.AppendAllText(filePath, line + Environment.NewLine);
+        }
+        catch (Exception ex)
+        {
+            Utils.Log.Warn($"Failed to write ctx-usage for playbook '{Playbook}': {ex.Message}");
+        }
+    }
+
+    // Serialize one recorded request: per-call totals plus the tool invocations it issued.
+    private static object CallRecord(ContextCall c) => new
+    {
+        c.Step,
+        c.Index,
+        source = c.Source.ToString().ToLowerInvariant(),
+        prompt_tokens = c.PromptTokens,
+        completion_tokens = c.CompletionTokens,
+        cached_tokens = c.CachedTokens,
+        total_tokens = c.TotalTokens,
+        fresh_tokens = c.FreshTokens,
+        tools = c.Tools.Select(t => new { t.Name, t.Command }).ToList(),
+    };
+
+    public static string CtxFilePath(string dataDirectory)
+        => Path.Combine(dataDirectory, FileName);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = false,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+}

--- a/src/OpenMono.Cli/Playbooks/PlaybookDefinition.cs
+++ b/src/OpenMono.Cli/Playbooks/PlaybookDefinition.cs
@@ -34,6 +34,10 @@ public sealed record PlaybookDefinition
 
     public bool LogOutput { get; init; } = false;
 
+    /// <summary>When true, the executor records per-call/per-step context usage and appends a per-run
+    /// object to <c>.openmono/data/ctx-usage.jsonl</c> (JSONL). Default off: no capture, no file.</summary>
+    public bool ReportCtx { get; init; } = false;
+
     /// <summary>Maximum tool-call rounds per step before aborting. Default: 10.</summary>
     public int MaxToolLoops { get; init; } = 10;
 

--- a/src/OpenMono.Cli/Playbooks/PlaybookExecutor.cs
+++ b/src/OpenMono.Cli/Playbooks/PlaybookExecutor.cs
@@ -22,6 +22,8 @@ public sealed class PlaybookExecutor : IDisposable
     private readonly bool _ownsDispatcher;
     private readonly SessionState _session;
 
+    private ContextUsageRecorder? _recorder;
+
     public PlaybookExecutor(
         ILlmClient llm,
         ToolRegistry tools,
@@ -117,6 +119,8 @@ public sealed class PlaybookExecutor : IDisposable
         var runId = state.SessionId;
         _permissions.PushPlaybookScope(runId, plan.Tools.Select(t => t.Name));
 
+        _recorder = new ContextUsageRecorder(playbook.Name, runId, _config.DataDirectory, active: playbook.ReportCtx);
+
         string? logPath = playbook.LogOutput ? BuildLogPath(_config.DataDirectory, playbook.Name, runId) : null;
         using var log = logPath is not null ? new StreamWriter(logPath, append: true) { AutoFlush = true } : null;
 
@@ -179,11 +183,13 @@ public sealed class PlaybookExecutor : IDisposable
                     }
                 }
 
+                _recorder?.BeginStep(step.Id);
                 var (output, stepError) = await RunStepAsync(step, stepContent, playbook, state, progressLabel, ct);
                 if (stepError is not null)
                 {
                     log?.WriteLine($"--- Step '{step.Id}' — ERROR ---\n{stepError}");
                     _renderer.WriteWarning($"  Step '{step.Id}' aborted — {stepError}");
+                    _recorder?.CompleteStep(step.Id);
                     return $"Playbook '{playbook.Name}' aborted at step '{step.Id}'.\n{stepError}";
                 }
                 log?.WriteLine($"--- Step '{step.Id}' — output ---\n{output}");
@@ -205,6 +211,7 @@ public sealed class PlaybookExecutor : IDisposable
 
                 state.CompleteStep(step.Id, output, step.Output);
                 _renderer.WriteInfo($"  Step '{step.Id}' — done");
+                _recorder?.CompleteStep(step.Id);
 
                 await state.SaveAsync(_config.DataDirectory, ct);
 
@@ -214,11 +221,17 @@ public sealed class PlaybookExecutor : IDisposable
 
             _renderer.WriteInfo($"Playbook '{playbook.Name}' completed ({state.CompletedSteps.Count} steps)");
             log?.WriteLine($"=== Playbook '{playbook.Name}' completed {DateTime.UtcNow:O} ({state.CompletedSteps.Count} steps) ===");
+            if (_recorder is not null) _recorder.Aborted = false;
             return finalOutput.Length > 0 ? finalOutput.ToString() : "Playbook completed.";
         }
         finally
         {
             _renderer.ClearToolProgress();
+
+            // Flush ctx-usage on EVERY exit path — normal completion, a step abort (doom loop,
+            // gate, script failure), or an exception. An aborted run still consumed context and
+            // must be reported so slot sizing reflects real usage.
+            _recorder?.Flush(_config.DataDirectory);
 
             try
             {
@@ -281,7 +294,6 @@ public sealed class PlaybookExecutor : IDisposable
     private async Task<(string Output, string? Error)> RunStepAsync(
         StepDefinition step, string content, PlaybookDefinition playbook, PlaybookState state, string progressLabel, CancellationToken ct)
     {
-
         var messages = new List<Message>
         {
             new()
@@ -360,6 +372,8 @@ public sealed class PlaybookExecutor : IDisposable
             var thinkingCollapsed = false;
             var thinkingChars = 0;
 
+            int usagePrompt = 0, usageCompletion = 0, usageCached = 0;
+
             var indicatorShown = false;
             using var indicatorCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             var indicatorTask = Task.Delay(500, indicatorCts.Token).ContinueWith(t =>
@@ -409,6 +423,15 @@ public sealed class PlaybookExecutor : IDisposable
                             pendingToolCalls.Add(tc);
                     }
 
+                    if (chunk.Usage is not null)
+                    {
+                        // Same providers split usage across two stream events (prompt at start, completion at
+                        // end). Accumulate across the whole request stream and record once below.
+                        usagePrompt += chunk.Usage.PromptTokens;
+                        usageCompletion += chunk.Usage.CompletionTokens;
+                        usageCached += chunk.Usage.CachedTokens;
+                    }
+
                     if (chunk.IsComplete) break;
                 }
             }
@@ -427,6 +450,9 @@ public sealed class PlaybookExecutor : IDisposable
             _renderer.ShowToolProgress(progressLabel);
             result.Append(textContent);
             lastTurnText = textContent.ToString();
+
+            _recorder?.Record(step.Id, ContextCallSource.Step, usagePrompt, usageCompletion, usageCached,
+                pendingToolCalls.Select(ToContextToolCall));
 
             if (pendingToolCalls.Count == 0)
                 break;
@@ -562,6 +588,7 @@ public sealed class PlaybookExecutor : IDisposable
             });
 
             var retryText = new StringBuilder();
+            int usagePrompt = 0, usageCompletion = 0, usageCached = 0;
             await foreach (var chunk in _llm.StreamChatAsync(messages, tools: null, correctionOptions, ct))
             {
                 if (chunk.TextDelta is not null)
@@ -569,11 +596,48 @@ public sealed class PlaybookExecutor : IDisposable
                     retryText.Append(chunk.TextDelta);
                     _renderer.StreamText(chunk.TextDelta);
                 }
+                if (chunk.Usage is not null)
+                {
+                    usagePrompt += chunk.Usage.PromptTokens;
+                    usageCompletion += chunk.Usage.CompletionTokens;
+                    usageCached += chunk.Usage.CachedTokens;
+                }
                 if (chunk.IsComplete) break;
             }
+            _recorder?.Record(stepId, ContextCallSource.JsonCorrection, usagePrompt, usageCompletion, usageCached);
             _renderer.EndAssistantResponse();
             candidate = retryText.ToString();
         }
+    }
+
+    /// <summary>Summarise a tool invocation into a short name + command label for context-usage
+    /// reporting. For Bash the <c>command</c> argument is surfaced directly; other tools fall back
+    /// to the arg that names the thing they acted on, else the raw arguments. Fail-open: bad
+    /// arguments never break the recorder.</summary>
+    private static ContextToolCall ToContextToolCall(ToolCall call)
+    {
+        var command = call.Arguments;
+        try
+        {
+            using var doc = JsonDocument.Parse(call.Arguments);
+            var root = doc.RootElement;
+            if (root.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var key in new[] { "command", "file_path", "script", "url", "path" })
+                {
+                    if (root.TryGetProperty(key, out var el) && el.ValueKind == JsonValueKind.String && !string.IsNullOrWhiteSpace(el.GetString()))
+                    {
+                        command = el.GetString()!;
+                        break;
+                    }
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            // fall through and keep raw arguments
+        }
+        return new ContextToolCall { Name = call.Name, Command = command };
     }
 
     /// <summary>Strips a markdown code fence if present, then narrows to the outermost {..}/[..] span.

--- a/src/OpenMono.Cli/Playbooks/PlaybookLoader.cs
+++ b/src/OpenMono.Cli/Playbooks/PlaybookLoader.cs
@@ -115,6 +115,7 @@ public sealed class PlaybookLoader
                 Tags = GetStringList(frontmatter, "tags"),
                 SkipPermissions = GetBool(frontmatter, "skip-permissions", false),
                 LogOutput = GetBool(frontmatter, "log-output", false),
+                ReportCtx = GetBool(frontmatter, "report-ctx", false),
                 MaxToolLoops = GetInt(frontmatter, "max-tool-loops", 10),
                 Temperature = GetDoubleOrNull(frontmatter, "temperature"),
                 Parameters = ParseParameters(frontmatter),

--- a/src/OpenMono.Tests/Playbooks/PlaybookExecutorTests.cs
+++ b/src/OpenMono.Tests/Playbooks/PlaybookExecutorTests.cs
@@ -129,10 +129,266 @@ public class PlaybookExecutorTests : IDisposable
         loaded!.IsStepCompleted("step1").Should().BeTrue();
     }
 
+    [Fact]
+    public async Task ExecuteAsync_ReportCtx_WritesCtxUsageJsonLine()
+    {
+        const string sessionId = "sess-ctx-write";
+        var playbook = new PlaybookDefinition
+        {
+            Name = "ctxpb",
+            Description = "ctx playbook",
+            ReportCtx = true,
+            Steps = [new StepDefinition { Id = "step1", InlinePrompt = "do the thing" }],
+        };
+
+        var config = new AppConfig { WorkingDirectory = _tempDir, DataDirectory = _tempDir };
+        var renderer = new TerminalRenderer();
+        var permissions = new PermissionEngine(config, renderer, renderer);
+        var llm = new UsageLlmClient();
+        using var executor = new PlaybookExecutor(llm, new ToolRegistry(), renderer, config, permissions);
+
+        await executor.ExecuteAsync(
+            playbook, new Dictionary<string, object>(), resumeFrom: null, sessionId, CancellationToken.None);
+
+        var filePath = ContextUsageRecorder.CtxFilePath(config.DataDirectory);
+        File.Exists(filePath).Should().BeTrue();
+
+        var lines = File.ReadAllLines(filePath).Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        lines.Should().HaveCount(1);
+
+        using var doc = JsonDocument.Parse(lines[0]);
+        var root = doc.RootElement;
+        root.GetProperty("run").GetInt32().Should().Be(1);
+        root.GetProperty("playbook").GetString().Should().Be("ctxpb");
+        root.GetProperty("session_id").GetString().Should().Be(sessionId);
+        root.GetProperty("aborted").GetBoolean().Should().BeFalse();
+
+        var steps = root.GetProperty("steps");
+        steps.GetArrayLength().Should().Be(1);
+        var step = steps[0];
+        step.GetProperty("step").GetString().Should().Be("step1");
+        step.GetProperty("prompt_tokens").GetInt32().Should().Be(60);
+        step.GetProperty("completion_tokens").GetInt32().Should().Be(10);
+        step.GetProperty("cached_tokens").GetInt32().Should().Be(25);
+        step.GetProperty("peak_prompt").GetInt32().Should().Be(60);
+        step.GetProperty("total_tokens").GetInt32().Should().Be(70);
+        step.GetProperty("fresh_tokens").GetInt32().Should().Be(35);
+        step.GetProperty("call_count").GetInt32().Should().Be(1);
+
+        // Calls are nested under the step, not a root-level array.
+        var stepCalls = step.GetProperty("calls");
+        stepCalls.GetArrayLength().Should().Be(1);
+        var call = stepCalls[0];
+        call.GetProperty("source").GetString().Should().Be("step");
+        call.GetProperty("total_tokens").GetInt32().Should().Be(70);
+        call.GetProperty("fresh_tokens").GetInt32().Should().Be(35);
+
+        var totals = root.GetProperty("totals");
+        totals.GetProperty("prompt_tokens").GetInt32().Should().Be(60);
+        totals.GetProperty("cached_tokens").GetInt32().Should().Be(25);
+        totals.GetProperty("total_tokens").GetInt32().Should().Be(70);
+        totals.GetProperty("fresh_tokens").GetInt32().Should().Be(35);
+        totals.GetProperty("call_count").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReportCtx_CapturesToolCommand()
+    {
+        const string sessionId = "sess-ctx-tool";
+        var playbook = new PlaybookDefinition
+        {
+            Name = "ctxbptool",
+            Description = "ctx tool playbook",
+            ReportCtx = true,
+            Steps = [new StepDefinition { Id = "step1", InlinePrompt = "do the thing" }],
+        };
+
+        var config = new AppConfig { WorkingDirectory = _tempDir, DataDirectory = _tempDir };
+        var renderer = new TerminalRenderer();
+        var permissions = new PermissionEngine(config, renderer, renderer);
+        using var executor = new PlaybookExecutor(
+            new ToolCallUsageLlmClient(), new ToolRegistry(), renderer, config, permissions);
+
+        var result = await executor.ExecuteAsync(
+            playbook, new Dictionary<string, object>(), resumeFrom: null, sessionId, CancellationToken.None);
+
+        var filePath = ContextUsageRecorder.CtxFilePath(config.DataDirectory);
+        var lines = File.ReadAllLines(filePath).Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        using var doc = JsonDocument.Parse(lines[0]);
+        var step = doc.RootElement.GetProperty("steps")[0];
+        var call = step.GetProperty("calls")[0];
+
+        call.GetProperty("tools").GetArrayLength().Should().Be(1);
+        var tool = call.GetProperty("tools")[0];
+        tool.GetProperty("name").GetString().Should().Be("Bash");
+        tool.GetProperty("command").GetString().Should().Be("echo hello world");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReportCtx_AbortMidRun_StillFlushes()
+    {
+        const string sessionId = "sess-ctx-abort";
+        // A Confirm gate without skip-permissions aborts in a non-interactive session before running
+        // the step's LLM call. Even so, the ctx-usage line must be written so aborted runs are visible.
+        var playbook = new PlaybookDefinition
+        {
+            Name = "ctxabort",
+            Description = "ctx abort playbook",
+            ReportCtx = true,
+            Steps = [new StepDefinition { Id = "step1", InlinePrompt = "do the thing", Gate = GateType.Confirm }],
+        };
+
+        var config = new AppConfig { WorkingDirectory = _tempDir, DataDirectory = _tempDir };
+        var renderer = new TerminalRenderer();
+        var permissions = new PermissionEngine(config, renderer, renderer);
+        using var executor = new PlaybookExecutor(
+            new UsageLlmClient(), new ToolRegistry(), renderer, config, permissions);
+
+        var result = await executor.ExecuteAsync(
+            playbook, new Dictionary<string, object>(), resumeFrom: null, sessionId, CancellationToken.None);
+
+        result.Should().Contain("requires interactive confirmation");
+
+        var filePath = ContextUsageRecorder.CtxFilePath(config.DataDirectory);
+        File.Exists(filePath).Should().BeTrue();
+        var lines = File.ReadAllLines(filePath).Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        lines.Should().HaveCount(1);
+
+        using var doc = JsonDocument.Parse(lines[0]);
+        var root = doc.RootElement;
+        root.GetProperty("run").GetInt32().Should().Be(1);
+        root.GetProperty("playbook").GetString().Should().Be("ctxabort");
+        root.GetProperty("aborted").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReportCtx_RerunAppendsIncrementingRun()
+    {
+        const string sessionId = "sess-ctx-rerun";
+        var playbook = new PlaybookDefinition
+        {
+            Name = "ctxrerun",
+            Description = "ctx rerun playbook",
+            ReportCtx = true,
+            Steps = [new StepDefinition { Id = "step1", InlinePrompt = "do the thing" }],
+        };
+
+        var config = new AppConfig { WorkingDirectory = _tempDir, DataDirectory = _tempDir };
+        var renderer = new TerminalRenderer();
+        var permissions = new PermissionEngine(config, renderer, renderer);
+        var llm = new UsageLlmClient();
+
+        using (var executor = new PlaybookExecutor(llm, new ToolRegistry(), renderer, config, permissions))
+        {
+            await executor.ExecuteAsync(
+                playbook, new Dictionary<string, object>(), resumeFrom: null, sessionId, CancellationToken.None);
+        }
+
+        using (var executor = new PlaybookExecutor(llm, new ToolRegistry(), renderer, config, permissions))
+        {
+            await executor.ExecuteAsync(
+                playbook, new Dictionary<string, object>(), resumeFrom: null, sessionId, CancellationToken.None);
+        }
+
+        var filePath = ContextUsageRecorder.CtxFilePath(config.DataDirectory);
+        var lines = File.ReadAllLines(filePath).Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
+        lines.Should().HaveCount(2);
+
+        using (var doc = JsonDocument.Parse(lines[0]))
+        {
+            doc.RootElement.GetProperty("run").GetInt32().Should().Be(1);
+        }
+        using (var doc = JsonDocument.Parse(lines[1]))
+        {
+            doc.RootElement.GetProperty("run").GetInt32().Should().Be(2);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithoutReportCtx_WritesNoCtxFile()
+    {
+        const string sessionId = "sess-ctx-off";
+        var playbook = new PlaybookDefinition
+        {
+            Name = "noctx",
+            Description = "no ctx playbook",
+            Steps = [new StepDefinition { Id = "step1", InlinePrompt = "do the thing" }],
+        };
+
+        var config = new AppConfig { WorkingDirectory = _tempDir, DataDirectory = _tempDir };
+        var renderer = new TerminalRenderer();
+        var permissions = new PermissionEngine(config, renderer, renderer);
+        using var executor = new PlaybookExecutor(
+            new UsageLlmClient(), new ToolRegistry(), renderer, config, permissions);
+
+        await executor.ExecuteAsync(
+            playbook, new Dictionary<string, object>(), resumeFrom: null, sessionId, CancellationToken.None);
+
+        var filePath = ContextUsageRecorder.CtxFilePath(config.DataDirectory);
+        File.Exists(filePath).Should().BeFalse();
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempDir))
             Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private sealed class UsageLlmClient : ILlmClient
+    {
+        public async IAsyncEnumerable<StreamChunk> StreamChatAsync(
+            IReadOnlyList<Message> messages,
+            JsonElement? tools,
+            LlmOptions options,
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            yield return new StreamChunk { TextDelta = "hi", IsComplete = true, Usage = new UsageInfo
+            {
+                PromptTokens = 60,
+                CompletionTokens = 10,
+                CachedTokens = 25,
+            } };
+            await Task.CompletedTask;
+        }
+
+        public void Dispose() { }
+    }
+
+    // Yields a Bash tool call + usage on the first request, then plain text so the executor's
+    // tool loop can terminate. Lets the context recorder capture the issued command.
+    private sealed class ToolCallUsageLlmClient : ILlmClient
+    {
+        private int _invocations;
+
+        public async IAsyncEnumerable<StreamChunk> StreamChatAsync(
+            IReadOnlyList<Message> messages,
+            JsonElement? tools,
+            LlmOptions options,
+            [EnumeratorCancellation] CancellationToken ct)
+        {
+            _invocations++;
+            if (_invocations == 1)
+            {
+                yield return new StreamChunk
+                {
+                    ToolCallDelta = new ToolCall
+                    {
+                        Id = "t1",
+                        Name = "Bash",
+                        Arguments = "{\"command\":\"echo hello world\"}",
+                    },
+                    Usage = new UsageInfo { PromptTokens = 50, CompletionTokens = 5, CachedTokens = 20 },
+                    IsComplete = true,
+                };
+            }
+            else
+            {
+                yield return new StreamChunk { TextDelta = "done", IsComplete = true };
+            }
+            await Task.CompletedTask;
+        }
+
+        public void Dispose() { }
     }
 
     private sealed class EchoLlmClient : ILlmClient


### PR DESCRIPTION
Adds an optional flag for playbooks to report context usage output to `/workspace/.openmono/data/ctx-usage.jsonl`